### PR TITLE
Fixed String[] array cast to Object[] array in Utils

### DIFF
--- a/src/main/java/junitparams/internal/Utils.java
+++ b/src/main/java/junitparams/internal/Utils.java
@@ -1,6 +1,6 @@
 package junitparams.internal;
 
-import java.lang.reflect.*;
+import java.lang.reflect.Method;
 
 /**
  * Some String utils to handle parameterised tests' results.
@@ -18,7 +18,7 @@ public class Utils {
         else if (paramSet instanceof String)
             result += paramSet;
         else
-            result += asCsvString(safelyCastParamsToArray(paramSet), paramIdx);
+            result += asCsvString(safelyCastParamsToArray(paramSet));
 
         return trimSpecialChars(result);
     }
@@ -28,21 +28,16 @@ public class Utils {
     }
 
     static Object[] safelyCastParamsToArray(Object paramSet) {
-        Object[] params;
-
-        if (paramSet instanceof String[]) {
-            params = new Object[]{paramSet};
+        final Object[] params;
+        if (paramSet instanceof Object[]) {
+            params = (Object[]) paramSet;
         } else {
-            try {
-                params = (Object[]) paramSet;
-            } catch (ClassCastException e) {
-                params = new Object[]{paramSet};
-            }
+            params = new Object[] {paramSet};
         }
         return params;
     }
 
-    private static String asCsvString(Object[] params, int paramIdx) {
+    private static String asCsvString(Object[] params) {
         if (params == null)
             return "null";
 

--- a/src/test/java/junitparams/MethodAnnotationArgumentTest.java
+++ b/src/test/java/junitparams/MethodAnnotationArgumentTest.java
@@ -52,8 +52,8 @@ public class MethodAnnotationArgumentTest {
     }
 
     @Test
-    @Parameters(method = "stringParams")
-    public void shouldPassStringParamsFromMethod(String parameter) {
+    @Parameters(method = "stringParamsWithNull")
+    public void shouldPassStringParamsWithNullFromMethod(String parameter) {
         // given
         List<String> acceptedParams = Arrays.asList("1", "2", "3", null);
 
@@ -61,8 +61,20 @@ public class MethodAnnotationArgumentTest {
         assertThat(acceptedParams).contains(parameter);
     }
 
-    Object[] stringParams() {
-        return genericArray("1", "2", "3", null);
+    Object[] stringParamsWithNull() {
+        return genericArray("1", "2", "3");
+    }
+
+    @Test
+    @Parameters(method = "multiStringParams")
+    public void shouldPassStringParamsWithNullFromMethod(String first, String second) {
+        assertThat(first).isEqualTo(second);
+    }
+
+    Object[] multiStringParams() {
+        return genericArray(
+                genericArray("test", "test"),
+                genericArray("ble", "ble"));
     }
 
     private static <T> T[] genericArray(T... elements) {

--- a/src/test/java/junitparams/MethodAnnotationArgumentTest.java
+++ b/src/test/java/junitparams/MethodAnnotationArgumentTest.java
@@ -62,7 +62,7 @@ public class MethodAnnotationArgumentTest {
     }
 
     Object[] stringParamsWithNull() {
-        return genericArray("1", "2", "3");
+        return genericArray("1", "2", "3", null);
     }
 
     @Test

--- a/src/test/java/junitparams/MethodAnnotationArgumentTest.java
+++ b/src/test/java/junitparams/MethodAnnotationArgumentTest.java
@@ -2,11 +2,14 @@ package junitparams;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.*;
-import org.junit.runner.*;
+import java.util.Arrays;
+import java.util.List;
 
-import junitparams.usage.person_example.*;
-import junitparams.usage.person_example.PersonTest.*;
+import junitparams.usage.person_example.PersonTest;
+import junitparams.usage.person_example.PersonTest.Person;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 @SuppressWarnings("unused")
 @RunWith(JUnitParamsRunner.class)
@@ -19,7 +22,7 @@ public class MethodAnnotationArgumentTest {
     }
 
     private Integer[] return1() {
-        return new Integer[] {1};
+        return new Integer[] { 1 };
     }
 
     @Test
@@ -39,12 +42,30 @@ public class MethodAnnotationArgumentTest {
     }
 
     private Integer[] return2() {
-        return new Integer[] {2};
+        return new Integer[] { 2 };
     }
 
     @Test
     @Parameters(source = PersonTest.class, method = "adultValues")
     public void testSingleMethodFromDifferentClass(int age, boolean valid) {
         assertThat(new Person(age).isAdult()).isEqualTo(valid);
+    }
+
+    @Test
+    @Parameters(method = "stringParams")
+    public void shouldPassStringParamsFromMethod(String parameter) {
+        // given
+        List<String> acceptedParams = Arrays.asList("1", "2", "3", null);
+
+        // then
+        assertThat(acceptedParams).contains(parameter);
+    }
+
+    Object[] stringParams() {
+        return genericArray("1", "2", "3", null);
+    }
+
+    private static <T> T[] genericArray(T... elements) {
+        return elements;
     }
 }

--- a/src/test/java/junitparams/MethodAnnotationArgumentTest.java
+++ b/src/test/java/junitparams/MethodAnnotationArgumentTest.java
@@ -67,7 +67,7 @@ public class MethodAnnotationArgumentTest {
 
     @Test
     @Parameters(method = "multiStringParams")
-    public void shouldPassStringParamsWithNullFromMethod(String first, String second) {
+    public void shouldPassMultiStringParams(String first, String second) {
         assertThat(first).isEqualTo(second);
     }
 

--- a/src/test/java/junitparams/internal/UtilsTest.java
+++ b/src/test/java/junitparams/internal/UtilsTest.java
@@ -1,0 +1,56 @@
+package junitparams.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class UtilsTest {
+
+    @Test
+    public void shouldSafelyCastStringArrayParamSetToArray() {
+        // given
+        Object paramSet = new String[] {"this", "is", "a", "test"};
+
+        // when
+        Object[] result = Utils.safelyCastParamsToArray(paramSet);
+
+        // then
+        assertThat(result).containsExactly("this", "is", "a", "test");
+    }
+
+    @Test
+    public void shouldSaflyCastIntegerArrayParamSetToArray() {
+        // given
+        Object paramSet = new Integer[] {1, 2, 3, 4};
+
+        // when
+        Object[] result = Utils.safelyCastParamsToArray(paramSet);
+
+        // then
+        assertThat(result).containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    public void shouldSaflyCastArrayParamSetToArray() {
+        // given
+        Object paramSet = new Object[] {1, "2", 30D};
+
+        // when
+        Object[] result = Utils.safelyCastParamsToArray(paramSet);
+
+        // then
+        assertThat(result).containsExactly(1, "2", 30D);
+    }
+
+    @Test
+    public void shouldCreateSingletonArrayWhenCastingObjectToArray() {
+        // given
+        Object paramSet = "test";
+
+        // when
+        Object[] result = Utils.safelyCastParamsToArray(paramSet);
+
+        // then
+        assertThat(result).containsExactly("test");
+    }
+}


### PR DESCRIPTION
Hi, there is a bug in current 1.0.3 version:
java.lang.IllegalStateException: While trying to create object of class class java.lang.String could not find constructor with arguments matching (type-wise) the ones given in parameters.

i found that:
String[] arg was casted to new String[] {arg} and method arguments count did not match.