### PR TITLE
Allow usage of enums as a data source

### DIFF
--- a/src/main/java/junitparams/internal/TestMethod.java
+++ b/src/main/java/junitparams/internal/TestMethod.java
@@ -285,12 +285,11 @@ public class TestMethod {
     }
 
     private Object[] fillResultWithAllParamProviderMethods(Class<?> sourceClass) {
-        List<Object> result;
         if (sourceClass.isEnum()) {
             return sourceClass.getEnumConstants();
-        } else {
-            result = getParamsFromSourceHierarchy(sourceClass);
         }
+
+        List<Object> result = getParamsFromSourceHierarchy(sourceClass);
         if (result.isEmpty())
             throw new RuntimeException(
                 "No methods starting with provide or they return no result in the parameters source class: "

--- a/src/test/java/junitparams/ParametersForEnumTest.java
+++ b/src/test/java/junitparams/ParametersForEnumTest.java
@@ -1,59 +1,53 @@
 package junitparams;
 
+import junitparams.internal.TestMethod;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
 import java.util.EnumSet;
-
-import junitparams.internal.TestMethod;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests for {@link TestMethod#fillResultWithAllParamProviderMethods} that verifies that enumeration values are passed.
+ * Tests for {@link TestMethod#fillResultWithAllParamProviderMethods} that
+ * verifies that enumeration values are passed.
  *
  * @author Bob Browning
  */
 @RunWith(JUnitParamsRunner.class)
 public class ParametersForEnumTest {
 
-  /**
-   * Ensures that the test is thread-safe.
-   */
-  private static ThreadLocal<EnumSet<Fruit>> threadUntested = new ThreadLocal<EnumSet<Fruit>>() {
-    @Override
-    protected EnumSet<Fruit> initialValue() {
-      return EnumSet.allOf(Fruit.class);
+    /**
+     * Set of fruits remaining to be tested.
+     */
+    private static Set<Fruit> untested =
+            Collections.synchronizedSet(EnumSet.allOf(Fruit.class));
+
+    @AfterClass
+    public static void after() {
+        assertThat(untested).isEmpty();
     }
-  };
 
-  @AfterClass
-  public static void after() {
-    try {
-      assertThat(threadUntested.get()).isEmpty();
-    } finally {
-      threadUntested.remove();
+    /**
+     * Sample enumeration.
+     */
+    public enum Fruit {
+        APPLE,
+        BANANA,
+        PEAR,
+        PLUM
     }
-  }
 
-  /**
-   * Sample enumeration.
-   */
-  public enum Fruit {
-    APPLE,
-    BANANA,
-    PEAR,
-    PLUM
-  }
-
-  @Test
-  @Parameters(source = Fruit.class)
-  public void testAllFruitsTested(Fruit fruit) throws Exception {
-    EnumSet<Fruit> untested = threadUntested.get();
-    // verify and remove fruit from outstanding expectations
-    assertThat(fruit).isIn(untested);
-    assertTrue("Failed to remove fruit from expectations", untested.remove(fruit));
-  }
+    @Test
+    @Parameters(source = Fruit.class)
+    public void testAllFruitsTested(Fruit fruit) throws Exception {
+        // verify and remove fruit from outstanding expectations
+        assertThat(fruit).isIn(untested);
+        assertTrue("Failed to remove fruit from expectations",
+                untested.remove(fruit));
+    }
 }


### PR DESCRIPTION
We have found it is often useful to have an enum as a data source and have found this leads to alot of redundant code

``` java

@Test
@Parameters(method = "typesOfFruit")
public void testSomething(Fruit fruit) {
}

@UsedReflectively
public Fruit[] typesOfFruit() {
  return Fruit.values();
}
```

a simple check when collecting parameters for tests for an enum class type allows a nicer reuse of the class attribute as in `@Parameters(source = Fruit.class)`
