### PR TITLE
Data mapper reader management

### DIFF
--- a/src/main/java/junitparams/mappers/BufferedReaderDataMapper.java
+++ b/src/main/java/junitparams/mappers/BufferedReaderDataMapper.java
@@ -6,7 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * A Data Mapper based on Buferred Reader.
+ * A Data Mapper based on Buffered Reader.
  */
 class BufferedReaderDataMapper implements DataMapper {
 

--- a/src/main/java/junitparams/mappers/BufferedReaderDataMapper.java
+++ b/src/main/java/junitparams/mappers/BufferedReaderDataMapper.java
@@ -1,0 +1,40 @@
+package junitparams.mappers;
+
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A Data Mapper based on Buferred Reader.
+ */
+class BufferedReaderDataMapper implements DataMapper {
+
+    private final int linesToSkip;
+
+    BufferedReaderDataMapper() {
+        this(0);
+    }
+
+    BufferedReaderDataMapper(int linesToSkip) {
+        this.linesToSkip = linesToSkip;
+    }
+
+    @Override
+    public Object[] map(Reader reader) {
+        BufferedReader br = new BufferedReader(reader);
+        String line;
+        List<String> result = new LinkedList<String>();
+        int lineNo = 0;
+        try {
+            while ((line = br.readLine()) != null) {
+                if (++lineNo > linesToSkip) {
+                    result.add(line);
+                }
+            }
+            return result.toArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/junitparams/mappers/CsvWithHeaderMapper.java
+++ b/src/main/java/junitparams/mappers/CsvWithHeaderMapper.java
@@ -11,23 +11,9 @@ import java.util.*;
  * @author Pawel Lipinski
  * 
  */
-public class CsvWithHeaderMapper implements DataMapper {
-    public Object[] map(Reader reader) {
-        BufferedReader br = new BufferedReader(reader);
-        String line;
-        List<String> result = new LinkedList<String>();
-        try {
-            try {
-                br.readLine(); // skip the header
-                while ((line = br.readLine()) != null) {
-                    result.add(line);
-                }
-                return result.toArray();
-            } finally {
-                reader.close();
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+public class CsvWithHeaderMapper extends BufferedReaderDataMapper {
+
+    public CsvWithHeaderMapper() {
+        super(1);
     }
 }

--- a/src/main/java/junitparams/mappers/IdentityMapper.java
+++ b/src/main/java/junitparams/mappers/IdentityMapper.java
@@ -15,22 +15,6 @@ import java.util.*;
  * @author Pawel Lipinski
  * 
  */
-public class IdentityMapper implements DataMapper {
-    public Object[] map(Reader reader) {
-        BufferedReader br = new BufferedReader(reader);
-        String line;
-        List<String> result = new LinkedList<String>();
-        try {
-            try {
-                while ((line = br.readLine()) != null) {
-                    result.add(line);
-                }
-                return result.toArray();
-            } finally {
-                reader.close();
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+public class IdentityMapper extends BufferedReaderDataMapper{
+
 }


### PR DESCRIPTION
Hi Guys,

This PR contains two cosmetic changes in `junitparams.mappers.DataMapper` implementations:

1) Removed duplication of logic reading files with `BufferedReader` in the following classes:
- `junitparams.mappers.CsvWithHeaderMapper`
- `junitparams.mappers.IdentityMapper`

2) Removed line closing Reader in Data Mapper implementations.
The reader lifecycle is externally managed by `junitparams.internal.parameters.ParametersFromFile` as it is mentioned in javadoc for `junitparams.mappers.DataMapper#map` - "...The reader is closed in the framework, so just read it :)..."