### PR TITLE
Update dependency version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ JUnitParams is available as Maven artifact:
 <dependency>
   <groupId>pl.pragmatists</groupId>
   <artifactId>JUnitParams</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 


### PR DESCRIPTION
In the README, update Maven dependency version to the latest (1.0.4)