### PR TITLE
Improved parameter type conversions

### DIFF
--- a/src/main/java/junitparams/converters/builtin/BigDecimalPropertyEditor.java
+++ b/src/main/java/junitparams/converters/builtin/BigDecimalPropertyEditor.java
@@ -1,0 +1,44 @@
+package junitparams.converters.builtin;
+
+import java.beans.PropertyEditorSupport;
+import java.math.BigDecimal;
+
+public class BigDecimalPropertyEditor extends PropertyEditorSupport {
+
+	@Override
+	public String getAsText() {
+		final Object obj = getValue();
+		if (null == obj) {
+			return "";
+		} else if (obj instanceof BigDecimal) {
+			return ((BigDecimal) obj).toString();
+		}
+		return null;
+	}
+
+	@Override
+	public void setAsText(String text) throws IllegalArgumentException {
+		if ((null == text) || text.trim().isEmpty()) {
+			setValue(null);
+		} else {
+			try {
+				BigDecimal num = new BigDecimal(text);
+				setValue(num);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException(text, e);
+			}
+		}
+	}
+
+	@Override
+	public String getJavaInitializationString() {
+		final Object obj = getValue();
+		if (null == obj) {
+			return "null";
+		} else if (obj instanceof BigDecimal) {
+			return "new java.math.BigDecimal(\"" + obj + "\")";
+		}
+		throw new IllegalStateException("bad value type: " + obj.getClass());
+	}
+
+}

--- a/src/main/java/junitparams/converters/builtin/BigIntegerPropertyEditor.java
+++ b/src/main/java/junitparams/converters/builtin/BigIntegerPropertyEditor.java
@@ -1,0 +1,45 @@
+package junitparams.converters.builtin;
+
+import java.beans.PropertyEditorSupport;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class BigIntegerPropertyEditor extends PropertyEditorSupport {
+
+	@Override
+	public String getAsText() {
+		final Object obj = getValue();
+		if (null == obj) {
+			return "";
+		} else if (obj instanceof BigInteger) {
+			return ((BigInteger) obj).toString();
+		}
+		return null;
+	}
+
+	@Override
+	public void setAsText(String text) throws IllegalArgumentException {
+		if ((null == text) || text.trim().isEmpty()) {
+			setValue(null);
+		} else {
+			try {
+				BigInteger num = new BigInteger(text);
+				setValue(num);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException(text, e);
+			}
+		}
+	}
+
+	@Override
+	public String getJavaInitializationString() {
+		final Object obj = getValue();
+		if (null == obj) {
+			return "null";
+		} else if (obj instanceof BigInteger) {
+			return "new java.math.BigInteger(\"" + obj + "\")";
+		}
+		throw new IllegalStateException("bad value type: " + obj.getClass());
+	}
+
+}

--- a/src/main/java/junitparams/converters/builtin/DateConverter.java
+++ b/src/main/java/junitparams/converters/builtin/DateConverter.java
@@ -1,0 +1,36 @@
+package junitparams.converters.builtin;
+
+import junitparams.converters.ConversionFailedException;
+import junitparams.converters.ParamConverter;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class DateConverter implements ParamConverter<Date> {
+
+	@Override
+	public Date convert(Object param, String options) throws ConversionFailedException {
+		if (null == param) {
+			return null;
+		}
+		final String textParam = param.toString();
+		if (textParam.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			final DateFormat format;
+			if ((null == options) || options.trim().isEmpty()) {
+				format = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US);
+			} else {
+				format = new SimpleDateFormat(options);
+			}
+			return format.parse(textParam);
+		} catch (ParseException e) {
+			throw new ConversionFailedException("Cannot convert '" + textParam + "' to Date: " + e.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/junitparams/converters/builtin/DateParam.java
+++ b/src/main/java/junitparams/converters/builtin/DateParam.java
@@ -1,0 +1,19 @@
+package junitparams.converters.builtin;
+
+import junitparams.converters.ConvertParam;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@ConvertParam(value = DateConverter.class)
+public @interface DateParam {
+
+	// Stereotype definition
+
+	String options() default "yyyy-MM-dd'T'HH:mm:ss";
+
+}

--- a/src/main/java/junitparams/converters/builtin/FileConverter.java
+++ b/src/main/java/junitparams/converters/builtin/FileConverter.java
@@ -1,0 +1,19 @@
+package junitparams.converters.builtin;
+
+import junitparams.converters.ConversionFailedException;
+import junitparams.converters.ParamConverter;
+
+import java.io.File;
+
+public class FileConverter implements ParamConverter<File> {
+
+	@Override
+	public File convert(Object param, String options) throws ConversionFailedException {
+		if (null == param) {
+			return null;
+		}
+		final String textParam = param.toString();
+		return new File(textParam);
+	}
+
+}

--- a/src/main/java/junitparams/converters/builtin/FileParam.java
+++ b/src/main/java/junitparams/converters/builtin/FileParam.java
@@ -1,0 +1,17 @@
+package junitparams.converters.builtin;
+
+import junitparams.converters.ConvertParam;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@ConvertParam(value = FileConverter.class)
+public @interface FileParam {
+
+	// Stereotype definition
+
+}

--- a/src/main/java/junitparams/converters/builtin/URIConverter.java
+++ b/src/main/java/junitparams/converters/builtin/URIConverter.java
@@ -1,0 +1,27 @@
+package junitparams.converters.builtin;
+
+import junitparams.converters.ConversionFailedException;
+import junitparams.converters.ParamConverter;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class URIConverter implements ParamConverter<URI> {
+
+	@Override
+	public URI convert(Object param, String options) throws ConversionFailedException {
+		if (null == param) {
+			return null;
+		}
+		final String textParam = param.toString();
+		if (textParam.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return new URI(textParam);
+		} catch (URISyntaxException e) {
+			throw new ConversionFailedException("Cannot convert '" + textParam + "' to URI: " + e.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/junitparams/converters/builtin/URIParam.java
+++ b/src/main/java/junitparams/converters/builtin/URIParam.java
@@ -1,0 +1,17 @@
+package junitparams.converters.builtin;
+
+import junitparams.converters.ConvertParam;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@ConvertParam(value = URIConverter.class)
+public @interface URIParam {
+
+	// Stereotype definition
+
+}

--- a/src/main/java/junitparams/internal/Annotations.java
+++ b/src/main/java/junitparams/internal/Annotations.java
@@ -1,0 +1,149 @@
+package junitparams.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utilities for annotation handling that simulate annotation inheritance. Users can
+ * create "stereotype annotation" {@code X} that is annotated by annotation {@code Y};
+ * methods from this class pretend that {@code X} "inherits" characteristics from {@code Y}.
+ *
+ * @author Boleslav Bobcik
+ */
+public final class Annotations {
+
+	/**
+	 * An annotation provides annotation type {@code T} if any of the following conditions is satisfied:
+	 * <ul>
+	 * <li>Annotation class is {@code T}</li>
+	 * <li>Annotation is annotated by an annotation that provides type {@code T}</li>
+	 * </ul>
+	 * This method simulates operator {@code instanceof} for annotations, as annotations don't support
+	 * inheritance at the language level.
+	 *
+	 * @param source           tested annotation instance
+	 * @param requestedType    base annotation class
+	 * @return {@code true}    if (1) class of {@code source} is {@code requestedType}, or (2) if any of
+	 *                         annotations (recursively) attached to the definition of {@code source}
+	 *                         has {@code requestedType}
+	 */
+	public static boolean providesType(Annotation source, Class<? extends Annotation> requestedType) {
+		if ((null == source) || (null == requestedType)) {
+			throw new NullPointerException();
+		} else if (requestedType.isInstance(source)) {
+			return true;
+		}
+		final List<Annotation> annotationChain = findAnnotationChain(source, requestedType);
+		return !annotationChain.isEmpty();
+	}
+
+	/**
+	 * Obtains value from annotation that provides a certain annotation type. If any stereotype annotation
+	 * defines a method that has identical name and compatible type as the method present in the {@code requestedType},
+	 * it will be used instead.
+	 * <p>
+	 * This method simulates an ability to override parent values in "inherited" annotations.
+	 *
+	 * @param source           annotation instance
+	 * @param requestedType    base annotation class
+	 * @param parameterName    name of a method in {@code requestedType}
+	 * @return                 value of the first occurrence of the parameter in an annotation in the inheritance chain
+	 *                         from {@code source} towards the nearest "parent" annotation of type {@code requestedType}.
+	 *                         Only parameters with type compatible with the type as defined in {@code requestedType}
+	 *                         are considered, incompatible parameters are ignored.
+     * @throws IllegalArgumentException
+	 *                         if {@code requestedType} does not contain parameter {@code parameterName} or
+	 *                         if there are problems obtaining its value
+	 */
+	public static Object getParameterValue(Annotation source, Class<? extends Annotation> requestedType, String parameterName) {
+		// Make sure that the parameter exists in the requested type definition
+		final Class<?> parameterType;
+		try {
+			final Method baseParamMethod = requestedType.getMethod(parameterName);
+			parameterType = baseParamMethod.getReturnType();
+		} catch (NoSuchMethodException e) {
+			throw new IllegalArgumentException("Annotation parameter '" + parameterName + "' not in annotation type " + requestedType);
+		}
+		// Process chain of annotations (annotation with requestedType is the last element)
+		final List<Annotation> annotationChain = findAnnotationChain(source, requestedType);
+		for (final Annotation annotation : annotationChain) {
+			final Class<? extends Annotation> annType = annotation.annotationType();
+			try {
+				final Method currMethod = annType.getMethod(parameterName);
+				final Class<?> returnType = currMethod.getReturnType();
+				if (parameterType.isAssignableFrom(returnType)) {
+					return currMethod.invoke(annotation);
+				}
+			} catch (NoSuchMethodException e) {
+				// Ignore this annotation and proceed to the next chain level
+			} catch (Exception e) {
+				throw new IllegalArgumentException("Cannot obtain parameter '" + parameterName + "' from annotation " + annotation, e);
+			}
+		}
+		throw new AssertionError("Annotation parameter '" + parameterName + "' not found");
+	}
+
+	private static List<Annotation> findAnnotationChain(Annotation start, Class<? extends Annotation> stopType) {
+		final Matcher blacklistMatcher = getBlacklistMatcher();
+		// Use non-recursive breadth-first search approach
+		final Deque<AnnotationTreeNode> searchCandidates = AnnotationTreeNode.initial(start);
+		while (!searchCandidates.isEmpty()) {
+			final AnnotationTreeNode node = searchCandidates.removeFirst();
+			if (stopType.isInstance(node.annotation)) {
+				return node.getChainFromRoot();
+			}
+			for (final Annotation subAnnotation : node.annotation.annotationType().getAnnotations()) {
+				blacklistMatcher.reset(subAnnotation.annotationType().getName());
+				if (!blacklistMatcher.find()) {
+					final AnnotationTreeNode childNode = new AnnotationTreeNode(subAnnotation, node);
+					searchCandidates.addLast(childNode);
+				}
+			}
+		}
+		return Collections.emptyList();
+	}
+
+	private Annotations() {
+		throw new AssertionError();
+	}
+
+	private static Matcher getBlacklistMatcher() {
+		return DEFAULT_BLACKLIST_PATTERN.matcher("");
+	}
+
+	private static final Pattern DEFAULT_BLACKLIST_PATTERN = Pattern.compile("^javax?\\.");
+
+	static final class AnnotationTreeNode {
+		final Annotation annotation;
+		final AnnotationTreeNode parent;
+
+		AnnotationTreeNode(Annotation ann, AnnotationTreeNode parent) {
+			this.annotation = ann;
+			this.parent = parent;
+		}
+
+		LinkedList<Annotation> getChainFromRoot() {
+			final LinkedList<Annotation> chain = new LinkedList<Annotation>();
+			AnnotationTreeNode node = this;
+			while (null != node) {
+				chain.addFirst(node.annotation);
+				node = node.parent;
+			}
+			return chain;
+		}
+
+		static Deque<AnnotationTreeNode> initial(Annotation ann) {
+			final Deque<AnnotationTreeNode> initialDeque = new LinkedList<AnnotationTreeNode>();
+			final AnnotationTreeNode rootNode = new AnnotationTreeNode(ann, null);
+			initialDeque.add(rootNode);
+			return initialDeque;
+		}
+	}
+
+}

--- a/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
+++ b/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
@@ -150,9 +150,10 @@ public class InvokeParameterisedMethod extends Statement {
 
     private Object castParameterUsingConverter(Object param, Annotation[] annotations) throws ConversionFailedException {
         for (Annotation annotation : annotations) {
-            if (annotation.annotationType().isAssignableFrom(ConvertParam.class)) {
-                Class<? extends ParamConverter<?>> converterClass = ((ConvertParam) annotation).value();
-                String options = ((ConvertParam) annotation).options();
+            if (Annotations.providesType(annotation, ConvertParam.class)) {
+                Class<? extends ParamConverter<?>> converterClass = (Class<? extends ParamConverter<?>>) Annotations.getParameterValue(
+                        annotation, ConvertParam.class, "value");
+                String options = (String) Annotations.getParameterValue(annotation, ConvertParam.class, "options");
                 try {
                     return converterClass.newInstance().convert(param, options);
                 } catch (ConversionFailedException e) {

--- a/src/test/java/junitparams/ParamsBuiltinConverterTest.java
+++ b/src/test/java/junitparams/ParamsBuiltinConverterTest.java
@@ -1,0 +1,56 @@
+package junitparams;
+
+import junitparams.converters.builtin.DateParam;
+import junitparams.converters.builtin.FileParam;
+import junitparams.converters.builtin.URIParam;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(JUnitParamsRunner.class)
+public class ParamsBuiltinConverterTest {
+
+    @Test
+    @Parameters({
+            "2015-03-20T14:30:59 , 2015-03-20T14:30:59",
+            "1999-12-31T23:59:59 , 1999-12-31T23:59:59"
+    })
+    public void shouldConvertIsoDate(@DateParam Date d, String refDate) throws Exception {
+        assertThat(d).isEqualToIgnoringMillis(refDate);
+    }
+
+    @Test
+    @Parameters({ "", " ", "\t", "\t\r\n \t\r\n" })
+    public void shouldConvertBlankAsNullDate(@DateParam Date d) throws Exception {
+        assertThat(d).isNull();
+    }
+
+    @Test
+    @Parameters({
+            "/etc/sys/ , other , /etc/sys/other",
+            "/a/b/c , d/e/f , /a/b/c/d/e/f",
+            "p/q/r , ../s/t/u , p/q/r/../s/t/u"
+    })
+    public void shouldConvertFile(@FileParam File parent, String child, @FileParam File fullPath) throws Exception {
+        final File referencePath = new File(parent, child);
+        assertThat(fullPath).isEqualTo(referencePath);
+    }
+
+    @Test
+    @Parameters({
+            "sftp://127.0.0.1:22/etc/fstab , sftp , 127.0.0.1",
+            "http://www.github.com/bbobcik , http , www.github.com"
+    })
+    public void shouldConvertURI(@URIParam URI uri, String refScheme, String refHost) throws Exception {
+        assertThat(uri).isNotNull();
+        assertThat(uri.getScheme()).isEqualTo(refScheme);
+        assertThat(uri.getHost()).isEqualTo(refHost);
+    }
+
+}

--- a/src/test/java/junitparams/ParamsBuiltinPropertyEditorTest.java
+++ b/src/test/java/junitparams/ParamsBuiltinPropertyEditorTest.java
@@ -1,0 +1,47 @@
+package junitparams;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class ParamsBuiltinPropertyEditorTest {
+
+	@Test
+	@Parameters({
+			"123456789.9876543212 , 123456789.9876543212",
+			"-99887766.5544332211 , -99887766.5544332211000",
+			"0.000000000000000001 , 0.000000000000000001",
+			"0, 0"
+	})
+	public void shouldParseNormalBigDecimals(BigDecimal num, String numAsText) {
+		assertThat(num).isEqualByComparingTo(numAsText);
+	}
+
+	@Test
+	@Parameters({ "", " ", "\t" })
+	public void shouldParseBlankAsNullBigDecimal(BigDecimal num) {
+		assertThat(num).isNull();
+	}
+
+	@Test
+	@Parameters({
+			"123456789 , 123456789",
+			"-99887766 , -99887766",
+			"0         , 0"
+	})
+	public void shouldParseNormalBigIntegers(BigInteger num, long referenceNum) {
+		assertThat(num).isEqualTo(BigInteger.valueOf(referenceNum));
+	}
+
+	@Test
+	@Parameters({ "", " ", "\t" })
+	public void shouldParseBlankAsNullBigInteger(BigInteger num) {
+		assertThat(num).isNull();
+	}
+
+}

--- a/src/test/java/junitparams/ParamsConverterTest.java
+++ b/src/test/java/junitparams/ParamsConverterTest.java
@@ -2,6 +2,8 @@ package junitparams;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.text.*;
 import java.util.*;
 
@@ -39,6 +41,34 @@ public class ParamsConverterTest {
         assertCalendarDate(calendar);
     }
 
+    @Test
+    @Parameters({ "01.12.2012" })
+    public void convertParamsUsingStereotype(@DateParam Date date) {
+        Calendar calendar = createCalendarWithDate(date);
+        assertCalendarDate(calendar);
+    }
+
+    @Test
+    @Parameters(method = "params")
+    public void convertParamsFromMethodUsingStereotype(@DateParam Date date) {
+        Calendar calendar = createCalendarWithDate(date);
+        assertCalendarDate(calendar);
+    }
+
+    @Test
+    @Parameters({ "2012-12-01" })
+    public void convertParamsUsingStereotypeWithOptionOverride(@DateParam(options = "yyyy-MM-dd") Date date) {
+        Calendar calendar = createCalendarWithDate(date);
+        assertCalendarDate(calendar);
+    }
+
+    @Test
+    @Parameters({ "2012-12-01" })
+    public void convertParamsUsingMultiLevelStereotype(@IsoDateParam Date date) {
+        Calendar calendar = createCalendarWithDate(date);
+        assertCalendarDate(calendar);
+    }
+
     private List<String> params() {
         return Arrays.asList("01.12.2012");
     }
@@ -69,7 +99,17 @@ public class ParamsConverterTest {
                 throw new RuntimeException(e);
             }
         }
+    }
 
+    @Retention(RetentionPolicy.RUNTIME)
+    @ConvertParam(value = StringToDateConverter.class)
+    public @interface DateParam {
+        String options() default "dd.MM.yyyy";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @ParamsConverterTest.DateParam(options = "yyyy-MM-dd")
+    public @interface IsoDateParam {
     }
 
 }


### PR DESCRIPTION
This pull request improves the current parameter type conversion in two ways:

- For unannotated parameters, it allows bean property editors (a feature of standard Java SE, although not very often used) to handle conversion from string to the requested target type. A couple of simple built-in property editors (for `java.math.BigDecimal` and `java.math.BigInteger`) are included. *This makes the parameter framework arbitrarily extensible for selected types where repeated parameter annotation would be perceived as clutter.*
- Extends mechanism of annotated parameters by concept of "stereotype" annotations, where the `@ConvertParam` annotation is not attached to the parameter itself, but instead annotates a definition of another annotation; this new annotation subsequently behaves as the original `@ConvertParam`. A couple of such conversion stereotype annotations are included (see `@DateParam`, `@URIParam` and `@FileParam`). *Unit test authors can use easy-to-remember, parameter-less, compact annotations (with fixed options if wanted) as aliases to fully qualified `@ConvertParam` annotations.*

Basic as well as advanced usage is demonstrated in included unit tests.