### PR TITLE
- implemented issue #56 (Regression: NPE on null arrays in the parameters)

### DIFF
--- a/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
+++ b/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
@@ -133,6 +133,7 @@ public class InvokeParameterisedMethod extends Statement {
 
     private boolean testMethodParamsHasVarargs(Object[] columns, Class<?>[] expectedParameterTypes) {
     	int paramLen = expectedParameterTypes.length;
+      if(expectedParameterTypes[paramLen-1] == null || columns[paramLen - 1] == null) return false;
         return expectedParameterTypes.length <= columns.length && expectedParameterTypes[paramLen-1].isArray()
         		&& expectedParameterTypes[paramLen-1].getComponentType().equals(columns[paramLen-1].getClass());
     }

--- a/src/test/java/junitparams/internal/TestMethodTest.java
+++ b/src/test/java/junitparams/internal/TestMethodTest.java
@@ -28,6 +28,19 @@ public class TestMethodTest {
                 new TestClass(this.getClass()));
     }
 
+    private Object nullArray() {
+        return new Object[] {/*is null*/  /* array */
+          new Object[] { false, new String[] { "1", "2" } },
+          new Object[] { true, null },
+        };
+    }
+
+    @Test
+    @Parameters(method = "nullArray")
+    public void testNullArraysArePassedIn(boolean isNullArray, String[] array) throws Exception {
+        assertEquals(isNullArray, array == null);
+    }
+
     @Test
     @Parameters({"a","b"})
     public void forOthersToWork(String arg) throws Exception {


### PR DESCRIPTION
- empty wrapper object arrays won't break all tests anymore
- added test method to avoid such "all-tests-breaking" scenarios in future