### PR TITLE
Use Arrays.equals

### DIFF
--- a/src/main/java/junitparams/internal/TestMethod.java
+++ b/src/main/java/junitparams/internal/TestMethod.java
@@ -2,6 +2,7 @@ package junitparams.internal;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Ignore;
@@ -61,7 +62,9 @@ public class TestMethod {
         if (!frameworkMethod.getName().equals(((TestMethod) obj).frameworkMethod.getName()))
             return false;
 
-        if (!frameworkMethod.getMethod().getParameterTypes().equals(((TestMethod) obj).frameworkMethod.getMethod().getParameterTypes()))
+        if (!Arrays.equals(
+                frameworkMethod.getMethod().getParameterTypes(),
+                ((TestMethod) obj).frameworkMethod.getMethod().getParameterTypes()))
             return false;
 
         return true;


### PR DESCRIPTION
This is a behavior change. [].equals is equivalent to == (reference comparison), which does not seem to be what is intended by the String comparison on the framework method name. Arrays.equals is now used to compare the Class items in the arrays for equality.

Note that some users cannot currently compile from source as .equals on arrays is configured to be a compile-time error.