### PR TITLE
Pass the most specific Description to rules.

### DIFF
--- a/src/main/java/junitparams/JUnitParamsRunner.java
+++ b/src/main/java/junitparams/JUnitParamsRunner.java
@@ -531,12 +531,18 @@ public class JUnitParamsRunner extends BlockJUnit4ClassRunner {
     private Statement withTestRules(FrameworkMethod method, List<TestRule> testRules,
             Statement statement) {
         return testRules.isEmpty() ? statement :
-            new RunRules(statement, testRules, describeParameterizedChild(method, statement));
+            new RunRules(statement, testRules, internalDescribeChild(method, statement));
     }
 
-    private Description describeParameterizedChild(FrameworkMethod method,
+    private Description internalDescribeChild(FrameworkMethod method,
         Statement methodInvoker) {
-        return parameterisedRunner.getParameterisedTestDescription(method, methodInvoker);
+        Description description =
+            parameterisedRunner.getParameterisedTestDescription(method, methodInvoker);
+        if (description == null) {
+            return describeChild(method);
+        }
+
+        return description;
     }
 
     /**

--- a/src/main/java/junitparams/JUnitParamsRunner.java
+++ b/src/main/java/junitparams/JUnitParamsRunner.java
@@ -3,6 +3,10 @@ package junitparams;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.internal.runners.model.ReflectiveCallable;
+import org.junit.internal.runners.statements.Fail;
+import org.junit.rules.RunRules;
+import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.NoTestsRemainException;
@@ -475,6 +479,64 @@ public class JUnitParamsRunner extends BlockJUnit4ClassRunner {
             child = describeChild(method);
 
         return child;
+    }
+
+    @Override
+    protected Statement methodBlock(FrameworkMethod method) {
+        Object test;
+        try {
+            test = new ReflectiveCallable() {
+                @Override
+                protected Object runReflectiveCall() throws Throwable {
+                    return createTest();
+                }
+            }.run();
+        } catch (Throwable e) {
+            return new Fail(e);
+        }
+
+        Statement statement = methodInvoker(method, test);
+        statement = possiblyExpectingExceptions(method, test, statement);
+        statement = withPotentialTimeout(method, test, statement);
+        statement = withBefores(method, test, statement);
+        statement = withAfters(method, test, statement);
+        statement = withRules(method, test, statement);
+        return statement;
+    }
+
+    private Statement withRules(FrameworkMethod method, Object target,
+            Statement statement) {
+        List<TestRule> testRules = getTestRules(target);
+        Statement result = statement;
+        result = withMethodRules(method, testRules, target, result);
+        result = withTestRules(method, testRules, result);
+
+        return result;
+    }
+
+    private Statement withMethodRules(FrameworkMethod method, List<TestRule> testRules,
+        Object target, Statement result) {
+        for (org.junit.rules.MethodRule each : getMethodRules(target)) {
+            if (!testRules.contains(each)) {
+                result = each.apply(result, method, target);
+            }
+        }
+        return result;
+    }
+
+    private List<org.junit.rules.MethodRule> getMethodRules(Object target) {
+        return rules(target);
+    }
+
+    private Statement withTestRules(FrameworkMethod method, List<TestRule> testRules,
+            Statement statement) {
+        return testRules.isEmpty() ? statement :
+            new RunRules(statement, testRules, describeParameterizedChild(method, statement));
+    }
+
+    private Description describeParameterizedChild(FrameworkMethod method,
+        Statement methodInvoker) {
+        return parameterisedRunner.getParameterisedTestDescription(method, methodInvoker);
     }
 
     /**

--- a/src/main/java/junitparams/internal/ParameterisedTestClassRunner.java
+++ b/src/main/java/junitparams/internal/ParameterisedTestClassRunner.java
@@ -148,6 +148,19 @@ public class ParameterisedTestClassRunner {
     }
 
     /**
+     * Returns description of a single parameterised method.
+     *
+     * @param method
+     * @param methodInvoker
+     * @return Description of a single parameterised method.
+     */
+    public Description getParameterisedTestDescription(
+        FrameworkMethod method, Statement methodInvoker) {
+        return parameterisedMethods.get(testMethods.get(method))
+            .getParameterisedTestDescription(methodInvoker);
+    }
+
+    /**
      * Returns description of a parameterised method.
      *
      * @param method TODO

--- a/src/main/java/junitparams/internal/ParameterisedTestClassRunner.java
+++ b/src/main/java/junitparams/internal/ParameterisedTestClassRunner.java
@@ -156,6 +156,11 @@ public class ParameterisedTestClassRunner {
      */
     public Description getParameterisedTestDescription(
         FrameworkMethod method, Statement methodInvoker) {
+        TestMethod testMethod = testMethods.get(method);
+
+        if (!testMethod.isParameterised())
+            return null;
+
         return parameterisedMethods.get(testMethods.get(method))
             .getParameterisedTestDescription(methodInvoker);
     }

--- a/src/main/java/junitparams/internal/ParameterisedTestMethodRunner.java
+++ b/src/main/java/junitparams/internal/ParameterisedTestMethodRunner.java
@@ -35,9 +35,13 @@ public class ParameterisedTestMethodRunner {
     }
 
     void runTestMethod(Statement methodInvoker, RunNotifier notifier) {
-        Description methodWithParams = findChildForParams(methodInvoker, method.describe());
+        Description methodWithParams = getParameterisedTestDescription(methodInvoker);
 
         runMethodInvoker(notifier, methodInvoker, methodWithParams);
+    }
+
+    Description getParameterisedTestDescription(Statement methodInvoker) {
+        return findChildForParams(methodInvoker, method.describe());
     }
 
     private void runMethodInvoker(RunNotifier notifier, Statement methodInvoker, Description methodWithParams) {

--- a/src/test/java/junitparams/RulesTest.java
+++ b/src/test/java/junitparams/RulesTest.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.*;
 import org.junit.rules.*;
 import org.junit.runner.*;
+import org.junit.runners.model.*;
 
 
 @RunWith(JUnitParamsRunner.class)
 public class RulesTest {
+    private static final String DESCRIPTION_TEMPLATE = "[%s] %s (%s)(%s)";
+
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
     @Rule
@@ -22,12 +25,41 @@ public class RulesTest {
     };
     @Rule
     public Timeout timeout = new Timeout(0);
+    @Rule
+    public DescriptionRule description = new DescriptionRule();
 
 
     @Test
     @Parameters("")
     public void shouldHandleRulesProperly(String n) {
-        assertThat(testName.getMethodName()).isEqualTo("shouldHandleRulesProperly");
+        assertThat(testName.getMethodName()).isEqualTo("[0]  (shouldHandleRulesProperly)");
     }
 
+    @Test
+    @Parameters({"0", "1"})
+    public void rulesShouldReceiveCorrectDescription(String value) {
+      assertThat(description.description.toString())
+          .isEqualTo(String.format(
+              DESCRIPTION_TEMPLATE, value, value, "rulesShouldReceiveCorrectDescription",
+              RulesTest.class.getName()));
+    }
+
+    private static class DescriptionRule implements TestRule {
+        private Description description;
+
+        private void setDescription(Description description) {
+            this.description = description;
+        }
+
+        @Override
+        public Statement apply(final Statement base, final Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                  setDescription(description);
+                  base.evaluate();
+                }
+            };
+        }
+    }
 }

--- a/src/test/java/junitparams/RulesTest.java
+++ b/src/test/java/junitparams/RulesTest.java
@@ -30,6 +30,11 @@ public class RulesTest {
 
 
     @Test
+    public void nonParameterisedMethod() {
+        assertThat(testName.getMethodName()).isEqualTo("nonParameterisedMethod");
+    }
+
+    @Test
     @Parameters("")
     public void shouldHandleRulesProperly(String n) {
         assertThat(testName.getMethodName()).isEqualTo("[0]  (shouldHandleRulesProperly)");


### PR DESCRIPTION
This is a behavior change. Prior to this change, rules for
parameterised tests received identical descriptions which
differed from the decription presented to the external
test runner. After this change, rules will receive the
more unique description that is presented to the external
test runner.

For example:

External test runner receives:
- rulesShouldReceiveCorrectDescription
  - [0] 0 (rulesShouldReceiveCorrectDescription)
  - [1] 1 (rulesShouldReceiveCorrectDescription)

Rules receive:

**Before**
- rulesShouldReceiveCorrectDescription
- rulesShouldReceiveCorrectDescription

**After**
- [0] 0 (rulesShouldReceiveCorrectDescription)
- [1] 1 (rulesShouldReceiveCorrectDescription)