### PR TITLE
Add field validation on test initialization (for JUnit Rules)

### DIFF
--- a/src/main/java/junitparams/JUnitParamsRunner.java
+++ b/src/main/java/junitparams/JUnitParamsRunner.java
@@ -400,7 +400,9 @@ public class JUnitParamsRunner extends BlockJUnit4ClassRunner {
         this.parametrizedTestMethodsFilter = new ParametrizedTestMethodsFilter(this,filter);
     }
 
+    @Override
     protected void collectInitializationErrors(List<Throwable> errors) {
+        super.validateFields(errors);
         for (Throwable throwable : errors)
             throwable.printStackTrace();
     }

--- a/src/test/java/junitparams/RulesTest.java
+++ b/src/test/java/junitparams/RulesTest.java
@@ -6,7 +6,6 @@ import org.junit.*;
 import org.junit.rules.*;
 import org.junit.runner.*;
 
-
 @RunWith(JUnitParamsRunner.class)
 public class RulesTest {
     @Rule
@@ -28,6 +27,25 @@ public class RulesTest {
     @Parameters("")
     public void shouldHandleRulesProperly(String n) {
         assertThat(testName.getMethodName()).isEqualTo("shouldHandleRulesProperly");
+    }
+
+    @Test
+    public void shouldProvideHelpfulExceptionMessageWhenRuleIsUsedImproperly() {
+        Result result = JUnitCore.runClasses(ProtectedRuleTest.class);
+        assertThat(result.getFailureCount()).isEqualTo(1);
+
+        String exceptionMessage = result.getFailures().get(0).getException().getMessage();
+        assertThat(exceptionMessage).isEqualTo("The @Rule 'testRule' must be public.");
+    }
+
+    public class ProtectedRuleTest {
+        @Rule
+        TestRule testRule;
+
+        @Test
+        public void test() {
+
+        }
     }
 
 }


### PR DESCRIPTION
Proposing to add some validation for Rules.  Previously, if you created a test with a Rule that was non-public or violated some other constraint JUnit places on Rules, you would get a rather unhelpful exception 
`java.lang.RuntimeException: How did getFields return a field we couldn't access?`

This has left me scratching my head a few times..  It now returns a more relevant message e.g.
`The @Rule 'testRule' must be public.`