### PR TITLE
Enabling of the simlple feature to use NULLs within @Parameters

### DIFF
--- a/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
+++ b/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
@@ -99,6 +99,8 @@ class InvokeParameterisedMethod extends Statement {
     private Object[] castParamsUsingConverters(Object[] columns) throws ConversionFailedException {
         Class<?>[] expectedParameterTypes = testMethod.getMethod().getParameterTypes();
 
+        fillPreformattedNulls(columns);
+
         if (testMethodParamsHasVarargs(columns, expectedParameterTypes)) {
             columns = columnsWithVarargs(columns, expectedParameterTypes);
         }
@@ -107,6 +109,15 @@ class InvokeParameterisedMethod extends Statement {
         verifySameSizeOfArrays(columns, expectedParameterTypes);
         columns = castAllParametersToProperTypes(columns, expectedParameterTypes, parameterAnnotations);
         return columns;
+    }
+
+    private Object[] fillPreformattedNulls(Object[] input) {
+        for(int i = 0; i < input.length; i++) {
+            if("/null/".equalsIgnoreCase(String.valueOf(input[i]))) {
+                input[i] = null;
+            }
+        }
+        return input;
     }
 
     private Object[] columnsWithVarargs(Object[] columns, Class<?>[] expectedParameterTypes) {
@@ -183,7 +194,7 @@ class InvokeParameterisedMethod extends Statement {
         if (clazz.isEnum())
             return (Enum.valueOf(clazz, (String) object));
         if (clazz.isAssignableFrom(String.class))
-            return object.toString();
+            return object;
         if (clazz.isAssignableFrom(Class.class))
             try {
                 return Class.forName((String) object);

--- a/src/test/java/junitparams/NullInferenceTest.java
+++ b/src/test/java/junitparams/NullInferenceTest.java
@@ -1,0 +1,60 @@
+package junitparams;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class NullInferenceTest {
+
+    @Test
+    @Parameters({
+            "/null/,, ",
+            "/null/, /two/, three"
+    })
+    public void shouldInferNullAsFirstParameter(String first, String second, String third) {
+        assertThat(first).isNull();
+        assertThat(second).isNotNull();
+        assertThat(third).isNotNull();
+    }
+
+    @Test
+    @Parameters({
+            ", /null/,",
+            "one, /null/, three"
+    })
+    public void shouldInferNullAsMiddleParameter(String first, String second, String third) {
+        assertThat(first).isNotNull();
+        assertThat(second).isNull();
+        assertThat(third).isNotNull();
+    }
+
+    @Test
+    @Parameters({
+            ",,/null/",
+            "one, two, /null/"
+    })
+    public void shouldInferNullAsLastParameter(String first, String second, String third) {
+        assertThat(first).isNotNull();
+        assertThat(second).isNotNull();
+        assertThat(third).isNull();
+    }
+
+    @Test
+    @Parameters({
+            "/null", "null/", "null", "/somedata/"
+    })
+    public void shouldNotInferNullValue(String inferred) {
+        assertThat(inferred).isNotNull();
+    }
+
+    @Test
+    @Parameters({
+            "/NULL/", "/null/", "/Null/", "/nuLL/"
+    })
+    public void shoudInferNullRagardlessToCase(String inferred) {
+        assertThat(inferred).isNull();
+    }
+
+}


### PR DESCRIPTION
Currently there is no possibility to use exactly
null values within annotation. One should create
method and instantiate all the stuff from there.

This commit enables such feature, that we can use
null values within annotation declaration. One
should just declare null as '/null/' and thus
it will be parsed and inferred.
