### PR TITLE
change default testcasenaming template

### DIFF
--- a/src/main/java/junitparams/naming/MacroSubstitutionNamingStrategy.java
+++ b/src/main/java/junitparams/naming/MacroSubstitutionNamingStrategy.java
@@ -14,7 +14,7 @@ public class MacroSubstitutionNamingStrategy implements TestCaseNamingStrategy {
     private static final Pattern MACRO_SPLIT_PATTERN = Pattern.compile(String.format("(?=%s)|(?<=%s)", MACRO_PATTERN, MACRO_PATTERN));
     private static final String MACRO_START = "{";
     private static final String MACRO_END = "}";
-    static final String DEFAULT_TEMPLATE = "[{index}] {params} ({method})";
+    static final String DEFAULT_TEMPLATE = "{method}({params}) [{index}]";
     private TestMethod method;
 
     public MacroSubstitutionNamingStrategy(TestMethod testMethod) {

--- a/src/test/java/junitparams/internal/TestMethodTest.java
+++ b/src/test/java/junitparams/internal/TestMethodTest.java
@@ -60,8 +60,8 @@ public class TestMethodTest {
         Description description = plainTestMethod.describe();
 
         assertEquals("forOthersToWork", description.getDisplayName());
-        assertEquals("[0] a (forOthersToWork)(junitparams.internal.TestMethodTest)", description.getChildren().get(0).getDisplayName());
-        assertEquals("[1] b (forOthersToWork)(junitparams.internal.TestMethodTest)", description.getChildren().get(1).getDisplayName());
+        assertEquals("forOthersToWork(a) [0](junitparams.internal.TestMethodTest)", description.getChildren().get(0).getDisplayName());
+        assertEquals("forOthersToWork(b) [1](junitparams.internal.TestMethodTest)", description.getChildren().get(1).getDisplayName());
     }
 
     @Test
@@ -70,9 +70,9 @@ public class TestMethodTest {
         Description description = arrayTestMethod.describe();
 
         assertEquals("forOthersToWorkWithArray", description.getDisplayName());
-        assertEquals("[0] a,b (forOthersToWorkWithArray)(junitparams.internal.TestMethodTest)",
+        assertEquals("forOthersToWorkWithArray(a,b) [0](junitparams.internal.TestMethodTest)",
                 description.getChildren().get(0).getDisplayName());
-        assertEquals("[1] b,a (forOthersToWorkWithArray)(junitparams.internal.TestMethodTest)",
+        assertEquals("forOthersToWorkWithArray(b,a) [1](junitparams.internal.TestMethodTest)",
                 description.getChildren().get(1).getDisplayName());
     }
     

--- a/src/test/java/junitparams/naming/MacroSubstitutionNamingStrategyTest.java
+++ b/src/test/java/junitparams/naming/MacroSubstitutionNamingStrategyTest.java
@@ -16,10 +16,10 @@ import static org.junit.Assert.assertEquals;
 public class MacroSubstitutionNamingStrategyTest {
 
     public Object parametersForTestNaming() {
-        return new Object[]{new Object[]{"withoutTestCaseAnnotation", "[0] value (withoutTestCaseAnnotation)"},
-                            new Object[]{"withAnnotationWithoutTemplate", "[0] value (withAnnotationWithoutTemplate)"},
-                            new Object[]{"withEmptyTemplate", "[0] value (withEmptyTemplate)"},
-                            new Object[]{"whenTemplateResultedToEmptyName", "[0] value (whenTemplateResultedToEmptyName)"},
+        return new Object[]{new Object[]{"withoutTestCaseAnnotation", "withoutTestCaseAnnotation(value) [0]"},
+                            new Object[]{"withAnnotationWithoutTemplate", "withAnnotationWithoutTemplate(value) [0]"},
+                            new Object[]{"withEmptyTemplate", "withEmptyTemplate(value) [0]"},
+                            new Object[]{"whenTemplateResultedToEmptyName", "whenTemplateResultedToEmptyName(value) [0]"},
                             new Object[]{"withoutMacro", "plain name"}, new Object[]{"withIndexMacro", "0"},
                             new Object[]{"withParamsMacro", "value"},
                             new Object[]{"withMethodNameMacro", "withMethodNameMacro"},


### PR DESCRIPTION
With the current default test case naming template i find it hard to see what test method that corresponds to the report.
I suggest making the test name naming template to be closer to a method call.

Also when the test results is presented in Jenkins the test cases will not be ordered by execution but by naming so if the index number is the first part of the test cases will not be grouped together. 