### PR TITLE
Speedups

### DIFF
--- a/src/main/java/junitparams/internal/Utils.java
+++ b/src/main/java/junitparams/internal/Utils.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
  * @author Pawel Lipinski
  */
 public class Utils {
-    private static final String REGEX_ALL_NEWLINES = "(\\r\\n|\\n|\\r)";
 
     public static String stringify(Object paramSet, int paramIdx) {
         String result = "[" + paramIdx + "] ";
@@ -71,7 +70,28 @@ public class Utils {
     }
 
     private static String trimSpecialChars(String result) {
-        return result.replace('(', '[').replace(')', ']').replaceAll(REGEX_ALL_NEWLINES, " ");
+        StringBuilder sb = new StringBuilder(result.length());
+        int i = 0;
+        while (i < result.length()) {
+            char c = result.charAt(i);
+            if (c == '(') {
+                sb.append('[');
+            } else if (c == ')') {
+                sb.append(']');
+            } else if (c == '\n') {
+                sb.append(' ');
+            } else if (c == '\r') {
+                sb.append(' ');
+                int j = i + 1;
+                if (j < result.length() && result.charAt(j) == '\n') {
+                    i++;
+                }
+            } else {
+                sb.append(c);
+            }
+            i++;
+        }
+        return sb.toString();
     }
 
     static Object[] safelyCastParamsToArray(Object paramSet) {

--- a/src/main/java/junitparams/naming/MacroSubstitutionNamingStrategy.java
+++ b/src/main/java/junitparams/naming/MacroSubstitutionNamingStrategy.java
@@ -15,21 +15,23 @@ public class MacroSubstitutionNamingStrategy implements TestCaseNamingStrategy {
     private static final String MACRO_START = "{";
     private static final String MACRO_END = "}";
     static final String DEFAULT_TEMPLATE = "[{index}] {params} ({method})";
+    private static final String[] DEFAULT_TEMPLATE_PARTS = MACRO_SPLIT_PATTERN.split(DEFAULT_TEMPLATE);
     private TestMethod method;
+    private String[] templateParts;
 
     public MacroSubstitutionNamingStrategy(TestMethod testMethod) {
         this.method = testMethod;
+        TestCaseName testCaseName = method.getAnnotation(TestCaseName.class);
+        String template = getTemplate(testCaseName);
+        this.templateParts = MACRO_SPLIT_PATTERN.split(template);
     }
 
     @Override
     public String getTestCaseName(int parametersIndex, Object parameters) {
-        TestCaseName testCaseName = method.getAnnotation(TestCaseName.class);
-
-        String template = getTemplate(testCaseName);
-        String builtName = buildNameByTemplate(template, parametersIndex, parameters);
+        String builtName = buildNameByTemplate(templateParts, parametersIndex, parameters);
 
         if (builtName.trim().isEmpty()) {
-            return buildNameByTemplate(DEFAULT_TEMPLATE, parametersIndex, parameters);
+            return buildNameByTemplate(DEFAULT_TEMPLATE_PARTS, parametersIndex, parameters);
         } else {
             return builtName;
         }
@@ -43,10 +45,8 @@ public class MacroSubstitutionNamingStrategy implements TestCaseNamingStrategy {
         return DEFAULT_TEMPLATE;
     }
 
-    private String buildNameByTemplate(String template, int parametersIndex, Object parameters) {
+    private String buildNameByTemplate(String[] parts, int parametersIndex, Object parameters) {
         StringBuilder nameBuilder = new StringBuilder();
-
-        String[] parts = MACRO_SPLIT_PATTERN.split(template);
 
         for (String part : parts) {
             String transformedPart = transformPart(part, parametersIndex, parameters);

--- a/src/test/java/junitparams/internal/UtilsTest.java
+++ b/src/test/java/junitparams/internal/UtilsTest.java
@@ -53,4 +53,52 @@ public class UtilsTest {
         // then
         assertThat(result).containsExactly("test");
     }
+
+    @Test
+    public void shouldReplaceUnixNewLineWithSpace() {
+        // given
+        Object paramSet = "\n";
+
+        // when
+        String result = Utils.stringify(paramSet);
+
+        // then
+        assertThat(result).isEqualTo(" ");
+    }
+
+    @Test
+    public void shouldReplaceMacNewLineWithSpace() {
+        // given
+        Object paramSet = "\r";
+
+        // when
+        String result = Utils.stringify(paramSet);
+
+        // then
+        assertThat(result).isEqualTo(" ");
+    }
+
+    @Test
+    public void shouldReplaceWindowsNewLineWithSpace() {
+        // given
+        Object paramSet = "\r\n";
+
+        // when
+        String result = Utils.stringify(paramSet);
+
+        // then
+        assertThat(result).isEqualTo(" ");
+    }
+
+    @Test
+    public void shouldReplaceParenthesisWithBrackets() {
+        // given
+        Object paramSet = "()";
+
+        // when
+        String result = Utils.stringify(paramSet);
+
+        // then
+        assertThat(result).isEqualTo("[]");
+    }
 }


### PR DESCRIPTION
If I write a test like
```java
@Test
@FileParameters("classpath:input.csv")
public void test(float f1, float f2, String s) {
    assertTrue(true);
}
```
where `input.csv` contains 1000 lines like
```
42.50729,1.53414,AD
```
then it takes ~14s to run the tests on my computer.

I profiled the code and most of time was spent building the test name strings. The hottest line was https://github.com/Pragmatists/JUnitParams/blob/master/src/main/java/junitparams/naming/MacroSubstitutionNamingStrategy.java#L49 which gets called once for each line in the input. I think the template will always be the same for each `TestMethod` so I've moved that line into the constructor so its only called once per method rather than once per input. My first commit is for this change and it reduced the test time to ~5s.

The next hottest line was https://github.com/Pragmatists/JUnitParams/blob/master/src/main/java/junitparams/internal/Utils.java#L74 (specifically the `.replaceAll`). My second commit replaces that with a `StringBuilder` which reduces the test time to ~3.5s. The new method could be simplified by allowing `\r\n` to be replaced with two spaces instead of one but I didn't want to make any functional changes.