### PR TITLE
Added option for trim-string-parameters behavior

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <groupId>pl.pragmatists</groupId>
     <artifactId>JUnitParams</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JUnitParams</name>
     <description>Better parameterised tests for JUnit</description>

--- a/src/main/java/junitparams/Parameters.java
+++ b/src/main/java/junitparams/Parameters.java
@@ -24,6 +24,12 @@ public @interface Parameters {
      */
     String[] value() default {};
 
+	/**
+     * By default all string parameters will be trimmed.
+     * You can change this behavior by changing option below to false.
+     */
+    boolean trimStringParams() default true;
+
     /**
      * Parameter values defined externally. The specified class must have at
      * least one public static method starting with <code>provide</code>

--- a/src/main/java/junitparams/custom/combined/CombinedParameters.java
+++ b/src/main/java/junitparams/custom/combined/CombinedParameters.java
@@ -21,4 +21,10 @@ public @interface CombinedParameters {
      * </code>
      */
     String[] value() default {};
+
+    /**
+     * By default all string parameters will be trimmed.
+     * You can change this behavior by changing option below to false.
+     */
+    boolean trimStringParams() default true;
 }

--- a/src/main/java/junitparams/custom/combined/CombinedParametersProvider.java
+++ b/src/main/java/junitparams/custom/combined/CombinedParametersProvider.java
@@ -19,7 +19,7 @@ public class CombinedParametersProvider implements ParametersProvider<CombinedPa
     public Object[] getParameters() {
         List<Object[]> list = new ArrayList<Object[]>();
         for(String parameterArray : combinedParameters.value()) {
-            list.add(Utils.splitAtCommaOrPipe(parameterArray));
+            list.add(Utils.splitAtCommaOrPipe(parameterArray, combinedParameters.trimStringParams()));
         }
 
         return Cartesian.getCartesianProductOf(list);

--- a/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
+++ b/src/main/java/junitparams/internal/InvokeParameterisedMethod.java
@@ -27,13 +27,13 @@ class InvokeParameterisedMethod extends Statement {
     private final Object testClass;
     private final String uniqueMethodId;
 
-    InvokeParameterisedMethod(FrameworkMethod testMethod, Object testClass, Object params, int paramSetIdx) {
+    InvokeParameterisedMethod(FrameworkMethod testMethod, Object testClass, Object params, int paramSetIdx, boolean trimStringParameters) {
         this.testMethod = testMethod;
         this.testClass = testClass;
         this.uniqueMethodId = Utils.uniqueMethodId(paramSetIdx - 1, params, testMethod.getName());
         try {
             if (params instanceof String)
-                this.params = castParamsFromString((String) params);
+                this.params = castParamsFromString((String) params, trimStringParameters);
             else {
                 this.params = castParamsFromObjects(params);
             }
@@ -42,10 +42,10 @@ class InvokeParameterisedMethod extends Statement {
         }
     }
 
-    private Object[] castParamsFromString(String params) throws ConversionFailedException {
+    private Object[] castParamsFromString(String params, boolean trimStringParameters) throws ConversionFailedException {
         Object[] columns = null;
         try {
-            columns = Utils.splitAtCommaOrPipe(params);
+            columns = Utils.splitAtCommaOrPipe(params, trimStringParameters);
             columns = castParamsUsingConverters(columns);
         } catch (RuntimeException e) {
             new IllegalArgumentException("Cannot parse parameters. Did you use ',' or '|' as column separator? "

--- a/src/main/java/junitparams/internal/ParameterisedTestClassRunner.java
+++ b/src/main/java/junitparams/internal/ParameterisedTestClassRunner.java
@@ -122,7 +122,7 @@ public class ParameterisedTestClassRunner {
         ParameterisedTestMethodRunner parameterisedMethod = parameterisedMethods.get(testMethod);
 
         return new InvokeParameterisedMethod(
-                method, testClass, parameterisedMethod.currentParamsFromAnnotation(), parameterisedMethod.count());
+                method, testClass, parameterisedMethod.currentParamsFromAnnotation(), parameterisedMethod.count(), testMethod.trimStringParameters());
     }
 
     /**

--- a/src/main/java/junitparams/internal/TestMethod.java
+++ b/src/main/java/junitparams/internal/TestMethod.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import junitparams.internal.options.OptionsReader;
 import org.junit.Ignore;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
@@ -25,6 +26,7 @@ public class TestMethod {
     private FrameworkMethodAnnotations frameworkMethodAnnotations;
     private Class<?> testClass;
     private ParametersReader parametersReader;
+    private OptionsReader optionsReader;
     private Object[] cachedParameters;
     private TestCaseNamingStrategy namingStrategy;
 
@@ -33,7 +35,7 @@ public class TestMethod {
         this.testClass = testClass.getJavaClass();
         frameworkMethodAnnotations = new FrameworkMethodAnnotations(method);
         parametersReader = new ParametersReader(testClass(), frameworkMethod);
-
+        optionsReader = new OptionsReader(frameworkMethod);
         namingStrategy = new MacroSubstitutionNamingStrategy(this);
     }
 
@@ -124,6 +126,10 @@ public class TestMethod {
             cachedParameters = parametersReader.read();
         }
         return cachedParameters;
+    }
+
+    public boolean trimStringParameters() {
+        return optionsReader.getTrimStringParams();
     }
 
     void warnIfNoParamsGiven() {

--- a/src/main/java/junitparams/internal/Utils.java
+++ b/src/main/java/junitparams/internal/Utils.java
@@ -30,10 +30,10 @@ public class Utils {
         return trimSpecialChars(result);
     }
 
-    public static String getParameterStringByIndexOrEmpty(Object paramSet, int parameterIndex) {
+    public static String getParameterStringByIndexOrEmpty(Object paramSet, int parameterIndex, boolean trimStringParameters) {
         Object[] params = safelyCastParamsToArray(paramSet);
         if (paramSet instanceof String) {
-            params = splitAtCommaOrPipe((String) paramSet);
+            params = splitAtCommaOrPipe((String) paramSet, trimStringParameters);
         }
         if (parameterIndex >= 0 && parameterIndex < params.length) {
             return addParamToResult("", params[parameterIndex]);
@@ -42,7 +42,7 @@ public class Utils {
         return "";
     }
 
-    public static String[] splitAtCommaOrPipe(String input) {
+    public static String[] splitAtCommaOrPipe(String input, boolean trimParameters) {
         ArrayList<String> result = new ArrayList<String>();
 
         char character = '\0';
@@ -58,14 +58,14 @@ public class Utils {
                     value.setCharAt(value.length() - 1, character);
                     continue;
                 }
-                result.add(value.toString().trim());
+                result.add(trimParameters ? value.toString().trim() : value.toString());
                 value = new StringBuilder();
                 continue;
             }
 
             value.append(character);
         }
-        result.add(value.toString().trim());
+        result.add(trimParameters ? value.toString().trim() : value.toString());
 
         return result.toArray(new String[]{});
     }

--- a/src/main/java/junitparams/internal/options/DefaultOptions.java
+++ b/src/main/java/junitparams/internal/options/DefaultOptions.java
@@ -1,0 +1,17 @@
+package junitparams.internal.options;
+
+public class DefaultOptions implements OptionsReaderStrategy {
+
+	public static final boolean DEFAULT_ALWAYS_TRIM_STRING_VALUES = true;
+	public static final boolean APPLICABLE_FOR_ALL = true;
+
+	@Override
+	public boolean getTrimStringParams() {
+		return DEFAULT_ALWAYS_TRIM_STRING_VALUES;
+	}
+
+	@Override
+	public boolean isApplicable() {
+		return APPLICABLE_FOR_ALL;
+	}
+}

--- a/src/main/java/junitparams/internal/options/OptionsFromCombinedParametersAnnotation.java
+++ b/src/main/java/junitparams/internal/options/OptionsFromCombinedParametersAnnotation.java
@@ -1,0 +1,23 @@
+package junitparams.internal.options;
+
+import junitparams.custom.combined.CombinedParameters;
+import org.junit.runners.model.FrameworkMethod;
+
+public class OptionsFromCombinedParametersAnnotation implements OptionsReaderStrategy {
+
+	private final CombinedParameters parametersAnnotation;
+
+	public OptionsFromCombinedParametersAnnotation(FrameworkMethod frameworkMethod) {
+		parametersAnnotation = frameworkMethod.getAnnotation(CombinedParameters.class);
+	}
+
+	@Override
+	public boolean getTrimStringParams() {
+		return parametersAnnotation.trimStringParams();
+	}
+
+	@Override
+	public boolean isApplicable() {
+		return parametersAnnotation != null;
+	}
+}

--- a/src/main/java/junitparams/internal/options/OptionsFromParametersAnnotation.java
+++ b/src/main/java/junitparams/internal/options/OptionsFromParametersAnnotation.java
@@ -1,0 +1,23 @@
+package junitparams.internal.options;
+
+import junitparams.Parameters;
+import org.junit.runners.model.FrameworkMethod;
+
+public class OptionsFromParametersAnnotation implements OptionsReaderStrategy {
+
+	private final Parameters parametersAnnotation;
+
+	public OptionsFromParametersAnnotation(FrameworkMethod frameworkMethod) {
+		parametersAnnotation = frameworkMethod.getAnnotation(Parameters.class);
+	}
+
+	@Override
+	public boolean getTrimStringParams() {
+		return parametersAnnotation.trimStringParams();
+	}
+
+	@Override
+	public boolean isApplicable() {
+		return parametersAnnotation != null;
+	}
+}

--- a/src/main/java/junitparams/internal/options/OptionsReader.java
+++ b/src/main/java/junitparams/internal/options/OptionsReader.java
@@ -1,0 +1,28 @@
+package junitparams.internal.options;
+
+import org.junit.runners.model.FrameworkMethod;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class OptionsReader {
+	private static final DefaultOptions DEFAULT_OPTIONS = new DefaultOptions();
+	private final List<OptionsReaderStrategy> strategies;
+
+	public OptionsReader(FrameworkMethod frameworkMethod) {
+		strategies = asList(
+				new OptionsFromParametersAnnotation(frameworkMethod),
+				new OptionsFromCombinedParametersAnnotation(frameworkMethod)
+		);
+	}
+
+	public boolean getTrimStringParams() {
+		for (OptionsReaderStrategy strategy : strategies) {
+			if (strategy.isApplicable()) {
+				return strategy.getTrimStringParams();
+			}
+		}
+		return DEFAULT_OPTIONS.getTrimStringParams();
+	}
+}

--- a/src/main/java/junitparams/internal/options/OptionsReaderStrategy.java
+++ b/src/main/java/junitparams/internal/options/OptionsReaderStrategy.java
@@ -1,0 +1,6 @@
+package junitparams.internal.options;
+
+public interface OptionsReaderStrategy {
+	boolean getTrimStringParams();
+	boolean isApplicable();
+}

--- a/src/main/java/junitparams/naming/MacroSubstitutionNamingStrategy.java
+++ b/src/main/java/junitparams/naming/MacroSubstitutionNamingStrategy.java
@@ -78,7 +78,7 @@ public class MacroSubstitutionNamingStrategy implements TestCaseNamingStrategy {
     private String substituteDynamicMacro(String macro, String macroKey, Object parameters) {
         if (isMethodParameterIndex(macroKey)) {
             int index = parseIndex(macroKey);
-            return Utils.getParameterStringByIndexOrEmpty(parameters, index);
+            return Utils.getParameterStringByIndexOrEmpty(parameters, index, method.trimStringParameters());
         }
 
         return macro;


### PR DESCRIPTION
By default JUnitParams removes any white characters from string parameters (string parameters are trimmed).

This can be dangerous especially when you try to test regular expressions.

For example:


```
import junitparams.JUnitParamsRunner;
import junitparams.Parameters;
import org.junit.Test;
import org.junit.runner.RunWith;

import java.util.regex.Pattern;

import static org.assertj.core.api.Assertions.assertThat;

@RunWith(JUnitParamsRunner.class)
public class SimpleTest {

	private static final String SHOULD_START_WITH_LETTER_A_AND_END_WITH_LETTER_Z = "^A.*Z$";
	private static final Pattern PATTERN = Pattern.compile(SHOULD_START_WITH_LETTER_A_AND_END_WITH_LETTER_Z);

	@Test
	@Parameters(value = {
			"AaaaaazzzZ",
			"    AaaaazzzzZ",
			"AaaaaaaaaZ     "
	})
	public void shouldValid(String inputString) {
		// given

		// when
		boolean matches = PATTERN.matcher(inputString).matches();

		// then
		assertThat(matches).isTrue();

	}
}
```


In given example all tests are green, but for second and third parameter regular expression should not match.


I added new parameter "trimStringParams" which by default is set to true. So with this new parameter nothing will be changed for old tests. But if you would like, you can change default behavior and set this parameter to false.


With new parameter set to false you can write something like this:

```
package pl.com.pekao.sso.internal.token.webservice.dto;

import junitparams.JUnitParamsRunner;
import junitparams.Parameters;
import org.junit.Test;
import org.junit.runner.RunWith;

import java.util.regex.Pattern;

import static org.assertj.core.api.Assertions.assertThat;

@RunWith(JUnitParamsRunner.class)
public class SimpleTest {

	private static final String SHOULD_START_WITH_LETTER_A_AND_END_WITH_LETTER_Z = "^A.*Z$";
	private static final Pattern PATTERN = Pattern.compile(SHOULD_START_WITH_LETTER_A_AND_END_WITH_LETTER_Z);

	@Test
	@Parameters(value = {
			"  AaaaaazzzZ   ",
			"    AaaaazzzzZ",
			"AaaaaaaaaZ     "
	}, trimStringParams = false)
	public void shouldValid(String inputString) {
		// given

		// when
		boolean matches = PATTERN.matcher(inputString).matches();

		// then
		assertThat(matches).isFalse();

	}
}
```