### PR TITLE
Memoize test method description

### DIFF
--- a/src/main/java/junitparams/internal/Memoizer.java
+++ b/src/main/java/junitparams/internal/Memoizer.java
@@ -1,0 +1,67 @@
+package junitparams.internal;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A memoization container to compute the value once and only once in a thread
+ * safe fashion.
+ *
+ * @param <T> the type to memoise
+ */
+abstract class Memoizer<T> {
+    private final ReentrantReadWriteLock.ReadLock readLock;
+    private final ReentrantReadWriteLock.WriteLock writeLock;
+
+    private volatile T value;
+
+    /**
+     * Construct a new memoisation container.
+     */
+    Memoizer() {
+        ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+        readLock = lock.readLock();
+        writeLock = lock.writeLock();
+    }
+
+    /**
+     * Get the memoized value. This will compute the value if the value has yet
+     * to be set.
+     *
+     * @return the memoized value
+     * @throws NullPointerException if {@link #computeValue()} returns null
+     */
+    public T get() {
+        // check for existing value
+        readLock.lock();
+        try {
+            if (value != null) {
+                return value;
+            }
+        } finally {
+            readLock.unlock();
+        }
+
+        // compute new value
+        writeLock.lock();
+        try {
+            // double check the value
+            if (value == null) {
+                T newValue = computeValue();
+                if (newValue == null) {
+                    throw new NullPointerException("computeValue should never null");
+                }
+                value = newValue;
+            }
+            return value;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Compute the memoized value.
+     *
+     * @return the value
+     */
+    protected abstract T computeValue();
+}

--- a/src/main/java/junitparams/internal/TestMethod.java
+++ b/src/main/java/junitparams/internal/TestMethod.java
@@ -28,6 +28,8 @@ public class TestMethod {
     private Object[] cachedParameters;
     private TestCaseNamingStrategy namingStrategy;
 
+    private final Memoizer<Description> description;
+
     public TestMethod(FrameworkMethod method, TestClass testClass) {
         this.frameworkMethod = method;
         this.testClass = testClass.getJavaClass();
@@ -35,6 +37,12 @@ public class TestMethod {
         parametersReader = new ParametersReader(testClass(), frameworkMethod);
 
         namingStrategy = new MacroSubstitutionNamingStrategy(this);
+        description = new Memoizer<Description>() {
+            @Override
+            protected Description computeValue() {
+                return TestMethod.this.computeDescription();
+            }
+        };
     }
 
     public String name() {
@@ -97,6 +105,11 @@ public class TestMethod {
     }
 
     Description describe() {
+        return description.get();
+    }
+
+    // visible for testing
+    Description computeDescription() {
         if (isNotIgnored() && !describeFlat()) {
             Description parametrised = Description.createSuiteDescription(name());
             Object[] params = parametersSets();

--- a/src/test/java/junitparams/internal/MemoizerTest.java
+++ b/src/test/java/junitparams/internal/MemoizerTest.java
@@ -1,0 +1,107 @@
+package junitparams.internal;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.synchronizedList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link Memoizer}.
+ */
+public class MemoizerTest {
+    private static void awaitUninterruptibly(CyclicBarrier barrier)
+            throws BrokenBarrierException {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    barrier.await();
+                    return;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private AtomicInteger counter;
+    private Memoizer<String> memoizer;
+
+    @Before
+    public void setUp() throws Exception {
+        counter = new AtomicInteger();
+        memoizer = new Memoizer<String>() {
+            @Override
+            protected String computeValue() {
+                counter.incrementAndGet();
+                return "SNARK";
+            }
+        };
+    }
+
+    @Test
+    public void get() throws Exception {
+        for (int i = 0; i < 100; i++) {
+            assertEquals("SNARK", memoizer.get());
+            assertEquals(1, counter.get());
+        }
+    }
+
+    @Test
+    public void getNullComputeValue() throws Exception {
+        try {
+            new Memoizer<String>() {
+                @Override
+                protected String computeValue() {
+                    return null;
+                }
+            }.get();
+            failBecauseExceptionWasNotThrown(NullPointerException.class);
+        } catch (NullPointerException npe) {
+            assertThat(npe)
+                    .hasMessage("computeValue should never null");
+        }
+    }
+
+    @Test
+    public void getThreaded() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(100);
+
+        final List<String> results = synchronizedList(new ArrayList<String>());
+        final CyclicBarrier barrier = new CyclicBarrier(100);
+        for (int i = 0; i < 100; i++) {
+            executorService.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        awaitUninterruptibly(barrier);
+                    } catch (BrokenBarrierException e) {
+                        throw new RuntimeException(e);
+                    }
+                    results.add(memoizer.get());
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+        assertThat(results)
+                .hasSize(100)
+                .containsOnly("SNARK");
+
+        assertEquals(1, counter.get());
+    }
+}

--- a/src/test/java/junitparams/internal/TestMethodMemorisationTest.java
+++ b/src/test/java/junitparams/internal/TestMethodMemorisationTest.java
@@ -1,0 +1,53 @@
+package junitparams.internal;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnitParamsRunner.class)
+public class TestMethodMemorisationTest {
+    private AtomicInteger counter;
+    private TestMethod testMethod;
+
+    @Before
+    public void setUp() throws Exception {
+        counter = new AtomicInteger();
+        Method method = TestMethodMemorisationTest.class
+                .getMethod("sampleTestMethod", String.class);
+
+        testMethod = new TestMethod(
+                new FrameworkMethod(method),
+                new TestClass(this.getClass())
+        ) {
+            @Override
+            Description computeDescription() {
+                counter.incrementAndGet();
+                return super.computeDescription();
+            }
+        };
+    }
+
+    @Test
+    public void testComputationOccursOnce() throws Exception {
+        for (int i = 0; i < 100; i++) {
+            testMethod.describe();
+        }
+        assertEquals(1, counter.get());
+    }
+
+    @Parameters({"SNARK"})
+    public void sampleTestMethod(String arg) {
+        fail("Unexpected invocation");
+    }
+}


### PR DESCRIPTION
Memoize test method description to prevent an exponential overhead when large number of iterations such as when using cartesian product of parameters.

When running a test method with many children iterations the ParameterisedTestMethodRunner#runTestMethod is invoked once for each iteration this in turn invokes the TestMethod#describe() which computes the description for the method and for each iteration. This computation results in a large redundancy in pre-processing time of each iteration for large data sets since for each iteration the result of TestMethod#describe will be equal to the previous result as none of the underlying state of the TestMethod is changing. 

To prove this a NO-OP test can be created that will take ~7m46s to complete, however with memoization of the description this is cut down to ~4s.

```java
// Java 8
import com.google.common.collect.Collections2;
import com.google.common.collect.ImmutableSet;

import junitparams.JUnitParamsRunner;
import junitparams.Parameters;
import org.junit.Test;
import org.junit.runner.RunWith;

import java.util.Collection;
import java.util.stream.Collectors;
import java.util.stream.Stream;

@RunWith(JUnitParamsRunner.class)
public class PermutationsTest {
  // 5040 permutations
  private static final ImmutableSet<String> MEMBERS = ImmutableSet.of(
      "SNARK", "BOOJUM", "JUBJUB", "BUTCHER", "BAKER", "BEAVER", "BELLMAN"
  );

  @Parameters(method = "largeDataSet")
  @Test
  public void testNothing(Stream<String> stream) {
    // does nothing, should be very fast
  }

  private Collection<Stream<String>> largeDataSet() {
    return Collections2.permutations(MEMBERS)
        .stream()
        .map(Collection::stream)
        .collect(Collectors.toList());
  }
}
```

Therefore this change is to allow large datasets to process and to improve the efficiency of smaller data sets through the memoization of the description upon first request.

Effectively without this the test above is performing `Description.createTestDescription` 25,401,600 times instead of 5040 times.