### PR TITLE
Allow simple iterable parameter types from target parameters methods

### DIFF
--- a/src/main/java/junitparams/internal/parameters/toarray/IterableResultToArray.java
+++ b/src/main/java/junitparams/internal/parameters/toarray/IterableResultToArray.java
@@ -3,10 +3,12 @@ package junitparams.internal.parameters.toarray;
 import java.util.ArrayList;
 import java.util.List;
 
-class IterableResultToArray implements ResultToArray {
+class IterableResultToArray extends SimpleIterableResultToArray {
     private Object result;
 
     IterableResultToArray(Object result) {
+        super(result);
+
         this.result = result;
     }
 
@@ -32,17 +34,6 @@ class IterableResultToArray implements ResultToArray {
             // Eat the exception and keep trying
         }
 
-        try {
-            List<Object[]> res = new ArrayList<Object[]>();
-            for (Object[] paramSet : (Iterable<Object[]>) result)
-                res.add(paramSet);
-            return res.toArray();
-        } catch (ClassCastException e1) {
-            // Iterable with consecutive paramsets, each of one param
-            List<Object> res = new ArrayList<Object>();
-            for (Object param : (Iterable<?>) result)
-                res.add(new Object[]{param});
-            return res.toArray();
-        }
+        return super.convert();
     }
 }

--- a/src/main/java/junitparams/internal/parameters/toarray/ParamsToArrayConverter.java
+++ b/src/main/java/junitparams/internal/parameters/toarray/ParamsToArrayConverter.java
@@ -1,9 +1,9 @@
 package junitparams.internal.parameters.toarray;
 
+import org.junit.runners.model.FrameworkMethod;
+
 import java.util.Arrays;
 import java.util.List;
-
-import org.junit.runners.model.FrameworkMethod;
 
 public class ParamsToArrayConverter {
     private FrameworkMethod frameworkMethod;
@@ -13,6 +13,18 @@ public class ParamsToArrayConverter {
     }
 
     public Object[] convert(Object result) {
+        // handle single iterable parameter result case where result is
+        // assignable to the test method parameter
+        if (frameworkMethod.getMethod().getParameterTypes().length == 1) {
+            Class<?> type = frameworkMethod.getMethod().getParameterTypes()[0];
+            if (type.isAssignableFrom(result.getClass())) {
+                SimpleIterableResultToArray converter = new SimpleIterableResultToArray(result);
+                if (converter.isApplicable()) {
+                    return converter.convert();
+                }
+            }
+        }
+
         List<? extends ResultToArray> converters = Arrays.asList(
                 new ObjectArrayResultToArray(result, frameworkMethod),
                 new IterableResultToArray(result),

--- a/src/main/java/junitparams/internal/parameters/toarray/SimpleIterableResultToArray.java
+++ b/src/main/java/junitparams/internal/parameters/toarray/SimpleIterableResultToArray.java
@@ -1,0 +1,33 @@
+package junitparams.internal.parameters.toarray;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class SimpleIterableResultToArray implements ResultToArray {
+    private final Object result;
+
+    SimpleIterableResultToArray(Object result) {
+        this.result = result;
+    }
+
+    @Override
+    public boolean isApplicable() {
+        return Iterable.class.isAssignableFrom(result.getClass());
+    }
+
+    @Override
+    public Object[] convert() {
+        try {
+            List<Object[]> res = new ArrayList<Object[]>();
+            for (Object[] paramSet : (Iterable<Object[]>) result)
+                res.add(paramSet);
+            return res.toArray();
+        } catch (ClassCastException e1) {
+            // Iterable with consecutive paramsets, each of one param
+            List<Object> res = new ArrayList<Object>();
+            for (Object param : (Iterable<?>) result)
+                res.add(new Object[]{param});
+            return res.toArray();
+        }
+    }
+}

--- a/src/test/java/junitparams/IterableMethodTest.java
+++ b/src/test/java/junitparams/IterableMethodTest.java
@@ -49,4 +49,40 @@ public class IterableMethodTest {
 
         return params;
     }
+
+    @Test
+    @Parameters
+    public void shouldHandleIterableParameters(Iterable<String> a) {
+        assertThat(a)
+                .hasSize(1)
+                .containsOnly("a");
+    }
+
+    public List<List<String>> parametersForShouldHandleIterableParameters() {
+        List<List<String>> params = new ArrayList<List<String>>();
+        List<String> nestedParams = new ArrayList<String>();
+
+        nestedParams.add("a");
+        params.add(nestedParams);
+
+        return params;
+    }
+
+    @Test
+    @Parameters
+    public void shouldHandleIterableParametersArr(Iterable<String> a) {
+        assertThat(a)
+                .hasSize(1)
+                .containsOnly("a");
+    }
+
+    public Object[] parametersForShouldHandleIterableParametersArr() {
+        List<List<String>> params = new ArrayList<List<String>>();
+        List<String> nestedParams = new ArrayList<String>();
+
+        nestedParams.add("a");
+        params.add(nestedParams);
+
+        return params.toArray();
+    }
 }

--- a/src/test/java/junitparams/internal/parameters/toarray/SimpleIterableResultToArrayTest.java
+++ b/src/test/java/junitparams/internal/parameters/toarray/SimpleIterableResultToArrayTest.java
@@ -1,0 +1,81 @@
+package junitparams.internal.parameters.toarray;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static junitparams.JUnitParamsRunner.$;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Tests for {@link SimpleIterableResultToArray}.
+ */
+public class SimpleIterableResultToArrayTest {
+
+    private static <T> ArrayList<T> newArrayList(T... args) {
+        ArrayList<T> list = new ArrayList<T>();
+        Collections.addAll(list, args);
+        return list;
+    }
+
+    private ArrayList<String> strings;
+
+    @Before
+    public void setUp() throws Exception {
+        strings = newArrayList("SNARK", "BOOJUM");
+    }
+
+    @Test
+    public void testSimpleIterableObjectArray() throws Exception {
+        Object[] actual = new SimpleIterableResultToArray(
+                newArrayList((Object[]) $("SNARK", "BOOJUM"))
+        ).convert();
+
+        assertThat(actual)
+                .isEqualTo($(
+                        $("SNARK"),
+                        $("BOOJUM")
+                ));
+    }
+
+    @Test
+    public void testSimpleIterable() throws Exception {
+        Object[] actual = new SimpleIterableResultToArray(strings).convert();
+        assertThat(actual)
+                .isEqualTo($(
+                        $("SNARK"),
+                        $("BOOJUM")
+                ));
+    }
+
+    @Test
+    public void testNestedManyIterable() throws Exception {
+        @SuppressWarnings("unchecked") ArrayList<ArrayList<String>> result =
+                newArrayList(strings, strings, strings);
+
+        Object[] actual = new SimpleIterableResultToArray(result).convert();
+        Object[] expected = new Object[]{
+                new Object[]{strings},
+                new Object[]{strings},
+                new Object[]{strings}
+        };
+        assertThat(actual)
+                .isEqualTo(expected);
+
+
+    }
+
+    @Test
+    public void testNestedSingleIterable() throws Exception {
+        @SuppressWarnings("unchecked") ArrayList<ArrayList<String>> result =
+                newArrayList(strings);
+
+        Object[] actual = new SimpleIterableResultToArray(result).convert();
+        Object[] expected = new Object[]{new Object[]{strings}};
+        assertThat(actual)
+                .isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
by suppressing recursive array conversion where parameters method result type and method parameter are assignable

Fixes #106