### PR TITLE
Improved cartesian parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ tmp/
 .project
 .externalToolBuilders/
 .classpath
-
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,12 @@
     </profiles>
     <dependencies>
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>1.0-rc2</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,79 @@
                     <releaseProfiles>release</releaseProfiles>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.guava:guava</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.google.guava:guava</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>repackaged.com.google.common</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Process gathered dependencies -->
+            <plugin>
+                <groupId>com.github.wvengen</groupId>
+                <artifactId>proguard-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>proguard</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- File with proguard configuration -->
+                    <proguardInclude>proguard.pro</proguardInclude>
+
+                    <!-- Exclude shaded classes -->
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                        </exclusion>
+                    </exclusions>
+                    <libs>
+                        <lib>${java.home}/lib/rt.jar</lib>
+                    </libs>
+
+                    <addMavenDescriptor>true</addMavenDescriptor>
+                    <obfuscate>false</obfuscate>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.sf.proguard</groupId>
+                        <artifactId>proguard-base</artifactId>
+                        <version>5.3.2</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -200,22 +273,22 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
         </dependency>
+
+        <!-- Test -->
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>15.0</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/proguard.pro
+++ b/proguard.pro
@@ -1,0 +1,54 @@
+-dontoptimize
+-dontobfuscate
+
+# See https://www.guardsquare.com/en/proguard/manual/examples#library
+
+-keepparameternames
+-renamesourcefileattribute SourceFile
+-keepattributes Exceptions,InnerClasses,Signature,Deprecated,
+                SourceFile,LineNumberTable,*Annotation*,EnclosingMethod
+
+-keep public class junitparams.** {
+      public protected *;
+}
+
+-keepclassmembernames class junitparams.** {
+    java.lang.Class class$(java.lang.String);
+    java.lang.Class class$(java.lang.String, boolean);
+}
+
+-keepclasseswithmembernames,includedescriptorclasses class junitparams.** {
+    native <methods>;
+}
+
+-keepclassmembers,allowoptimization enum junitparams.** {
+    public static **[] values(); public static ** valueOf(java.lang.String);
+}
+
+-keepclassmembers class junitparams.** implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+# JUnitParams related ignorables (reflective access)
+-dontnote junitparams.internal.parameters.ParametersFromCustomProvider$ParametersProviderFactory
+
+# Guava related ignorables
+-dontwarn com.google.j2objc.annotations.Weak
+-dontwarn java.lang.ClassValue
+-dontwarn javax.annotation.**
+-dontwarn javax.inject.**
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-dontwarn sun.misc.Unsafe
+
+# Guava related ignorables (reflective access - generally pertaining to Android)
+-dontnote repackaged.com.google.common.base.Throwables
+-dontnote repackaged.com.google.common.base.internal.Finalizer
+-dontnote repackaged.com.google.common.cache.Striped64
+-dontnote repackaged.com.google.common.cache.Striped64$Cell
+-dontnote repackaged.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper
+-dontnote repackaged.com.google.common.util.concurrent.MoreExecutors

--- a/proguard.pro
+++ b/proguard.pro
@@ -40,6 +40,7 @@
 # Guava related ignorables
 -dontwarn com.google.j2objc.annotations.Weak
 -dontwarn java.lang.ClassValue
+-dontwarn java.lang.SafeVarargs
 -dontwarn javax.annotation.**
 -dontwarn javax.inject.**
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement

--- a/src/main/java/junitparams/custom/combined/CartesianParameters.java
+++ b/src/main/java/junitparams/custom/combined/CartesianParameters.java
@@ -1,0 +1,28 @@
+package junitparams.custom.combined;
+
+import junitparams.Parameters;
+import junitparams.custom.CustomParameters;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A cartesian based parameter set that reuses the {@link Parameters} functionality as a source of parameter sets.
+ */
+@CustomParameters(provider = CartesianParametersProvider.class)
+@Retention(RUNTIME)
+@Target(METHOD)
+@SuppressWarnings("WeakerAccess")
+public @interface CartesianParameters {
+    /**
+     * A set of {@link Parameters} annotations.
+     *
+     * @return the annotations
+     */
+    Parameters[] value();
+}

--- a/src/main/java/junitparams/custom/combined/CartesianParametersProvider.java
+++ b/src/main/java/junitparams/custom/combined/CartesianParametersProvider.java
@@ -1,0 +1,84 @@
+package junitparams.custom.combined;
+
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import junitparams.Parameters;
+import junitparams.custom.ParametersProvider;
+import junitparams.internal.parameters.*;
+import org.junit.runners.model.FrameworkMethod;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link ParametersProvider} implementation supporting {@link CartesianParameters} which allow for a simpler transition
+ * between {@link Parameters} and the cartesian product form.
+ */
+@SuppressWarnings("WeakerAccess")
+public class CartesianParametersProvider implements ParametersProvider<CartesianParameters> {
+
+    /**
+     * A {@link ResultAdapter} to convert the collected parameters for cartesian permutation.
+     */
+    private static class CartesianResultAdapter implements ResultAdapter {
+        @Override
+        public Object[] adapt(Object result) {
+            ImmutableList<?> listResult = asImmutableList(result);
+            return listResult.toArray(new Object[listResult.size()]);
+        }
+
+        private ImmutableList<?> asImmutableList(Object result) {
+            if (result instanceof Iterable) {
+                return ImmutableList.copyOf((Iterable<?>) result);
+            }
+            if (result instanceof Iterator) {
+                return ImmutableList.copyOf((Iterator<?>) result);
+            }
+            if (result.getClass().isArray()) {
+                return ImmutableList.copyOf(((Object[]) result));
+            }
+            return ImmutableList.of(result);
+        }
+    }
+
+    private final Class<?> testClass;
+
+    private final FrameworkMethod frameworkMethod;
+
+    private CartesianParameters parametersAnnotation;
+
+    /**
+     * Constructs a new provider of cartesian parameters.
+     *
+     * @param testClass       the context test class
+     * @param frameworkMethod the context framework method
+     */
+    public CartesianParametersProvider(Class<?> testClass, FrameworkMethod frameworkMethod) {
+        this.testClass = checkNotNull(testClass, "testClass must not be null");
+        this.frameworkMethod = checkNotNull(frameworkMethod, "frameworkMethod must not be null");
+    }
+
+    @Override
+    public Object[] getParameters() {
+        ImmutableList<Object[]> objects = FluentIterable.from(Arrays.asList(parametersAnnotation.value()))
+                .transform(new Function<Parameters, Object[]>() {
+                    @Override
+                    public Object[] apply(Parameters parameters) {
+                        return ParametersFromParametersAnnotation.parametersFor(
+                                testClass, frameworkMethod, parameters, new CartesianResultAdapter()
+                        );
+                    }
+                }).toList();
+
+        return Cartesian.getCartesianProductOf(new ArrayList<Object[]>(objects));
+    }
+
+    @Override
+    public void initialize(CartesianParameters parametersAnnotation) {
+        this.parametersAnnotation = checkNotNull(parametersAnnotation, "parametersAnnotation must not be null");
+    }
+}

--- a/src/main/java/junitparams/internal/parameters/DefaultParameterizationStrategyFactory.java
+++ b/src/main/java/junitparams/internal/parameters/DefaultParameterizationStrategyFactory.java
@@ -1,0 +1,26 @@
+package junitparams.internal.parameters;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import junitparams.Parameters;
+import org.junit.runners.model.FrameworkMethod;
+
+import java.util.List;
+
+/**
+ * The default internal {@link ParametrizationStrategyFactory}.
+ */
+@AutoService(ParametrizationStrategyFactory.class)
+public class DefaultParameterizationStrategyFactory implements ParametrizationStrategyFactory {
+    @Override
+    public List<ParametrizationStrategy> createStrategies(Class<?> testClass, FrameworkMethod frameworkMethod) {
+        ImmutableList.Builder<ParametrizationStrategy> builder = ImmutableList.<ParametrizationStrategy>builder()
+                .add(new ParametersFromCustomProvider(testClass, frameworkMethod));
+
+        /* @Nullable */ Parameters annotation = frameworkMethod.getAnnotation(Parameters.class);
+        if (annotation != null) {
+            builder.add(ParametersFromParametersAnnotation.create(testClass, frameworkMethod, annotation));
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/junitparams/internal/parameters/ImmutableParameterTypeSupplier.java
+++ b/src/main/java/junitparams/internal/parameters/ImmutableParameterTypeSupplier.java
@@ -1,0 +1,67 @@
+package junitparams.internal.parameters;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.runners.model.FrameworkMethod;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * An immutable {@link ParameterTypeSupplier}.
+ */
+class ImmutableParameterTypeSupplier implements ParameterTypeSupplier {
+    /**
+     * Creates a new {@link ImmutableParameterTypeSupplier} from the provided {@link FrameworkMethod}'s parameter types.
+     *
+     * @param frameworkMethod the framework method to acquire the parameters of
+     * @return an {@link ImmutableParameterTypeSupplier}
+     */
+    static ImmutableParameterTypeSupplier copyFrom(FrameworkMethod frameworkMethod) {
+        return of(frameworkMethod.getMethod().getParameterTypes());
+    }
+
+    /**
+     * Creates a new {@link ImmutableParameterTypeSupplier} from the provided parameter types.
+     *
+     * @param types the parameter types
+     * @return an {@link ImmutableParameterTypeSupplier}
+     */
+    static ImmutableParameterTypeSupplier copyOf(Iterable<Class<?>> types) {
+        return new ImmutableParameterTypeSupplier(types);
+    }
+
+    /**
+     * Creates a new {@link ImmutableParameterTypeSupplier} as a copy of another {@link ParameterTypeSupplier}.
+     *
+     * @param original the original {@link ParameterTypeSupplier}
+     * @return an {@link ImmutableParameterTypeSupplier}
+     */
+    static ImmutableParameterTypeSupplier copyOf(ParameterTypeSupplier original) {
+        if (original instanceof ImmutableParameterTypeSupplier) {
+            return (ImmutableParameterTypeSupplier) original;
+        }
+        return new ImmutableParameterTypeSupplier(original.getParameterTypes());
+    }
+
+    /**
+     * Creates a new {@link ImmutableParameterTypeSupplier} from the provided parameter types.
+     *
+     * @param types the parameter types
+     * @return an {@link ImmutableParameterTypeSupplier}
+     */
+    public static ImmutableParameterTypeSupplier of(Class<?>... types) {
+        return new ImmutableParameterTypeSupplier(ImmutableList.copyOf(types));
+    }
+
+    private ImmutableList<Class<?>> types;
+
+    private ImmutableParameterTypeSupplier(Iterable<Class<?>> types) {
+        this.types = ImmutableList.copyOf(checkNotNull(types, "types must not be null"));
+    }
+
+    @Override
+    public List<Class<?>> getParameterTypes() {
+        return types;
+    }
+}

--- a/src/main/java/junitparams/internal/parameters/ParameterTypeSupplier.java
+++ b/src/main/java/junitparams/internal/parameters/ParameterTypeSupplier.java
@@ -1,0 +1,15 @@
+package junitparams.internal.parameters;
+
+import java.util.List;
+
+/**
+ * A supplier of parameter types.
+ */
+public interface ParameterTypeSupplier {
+    /**
+     * A list of parameter types.
+     *
+     * @return the parameter types
+     */
+    List<Class<?>> getParameterTypes();
+}

--- a/src/main/java/junitparams/internal/parameters/ParametersFromCustomProvider.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromCustomProvider.java
@@ -1,16 +1,149 @@
 package junitparams.internal.parameters;
 
-import org.junit.runners.model.FrameworkMethod;
-
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import junitparams.custom.ParametersProvider;
 import junitparams.internal.annotation.CustomParametersDescriptor;
 import junitparams.internal.annotation.FrameworkMethodAnnotations;
+import org.junit.runners.model.FrameworkMethod;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 class ParametersFromCustomProvider implements ParametrizationStrategy {
 
+    /**
+     * A factory of {@link ParametersProvider} instances.
+     */
+    private abstract static class ParametersProviderFactory {
+
+        private static final LoadingCache<Class<? extends ParametersProvider<? extends Annotation>>, ParametersProviderFactory> cache =
+                CacheBuilder.newBuilder().build(
+                        new CacheLoader<Class<? extends ParametersProvider<? extends Annotation>>, ParametersProviderFactory>() {
+                            @Override
+                            public ParametersProviderFactory load(Class<? extends ParametersProvider<? extends Annotation>> providerClass) throws Exception {
+                                return resolveConstructor(providerClass);
+                            }
+                        }
+                );
+
+        /**
+         * Creates a {@link ParametersProviderFactory} for the specified {@link ParametersProvider} class.
+         *
+         * @param providerClass the provider class
+         * @param <T>           the provider class type
+         * @return the factory
+         */
+        static <T extends ParametersProvider<? extends Annotation>> ParametersProviderFactory forType(Class<T> providerClass) {
+            return cache.getUnchecked(providerClass);
+        }
+
+        private static <T extends ParametersProvider<? extends Annotation>> ParametersProviderFactory
+        resolveConstructor(Class<T> providerClass) {
+            try {
+                final Constructor<T> cons = providerClass.getConstructor(Class.class, FrameworkMethod.class);
+                return new ParametersProviderFactory() {
+                    @Override
+                    protected ParametersProvider<? extends Annotation> checkedNewInstance(Class<?> testClass, FrameworkMethod frameworkMethod)
+                            throws IllegalAccessException, InvocationTargetException, InstantiationException {
+                        checkNotNull(testClass, "testClass must not be null");
+                        checkNotNull(frameworkMethod, "frameworkMethod must not be null");
+                        return cons.newInstance(testClass, frameworkMethod);
+                    }
+                };
+            } catch (NoSuchMethodException ignored) {
+            }
+
+            try {
+                final Constructor<T> cons = providerClass.getConstructor(FrameworkMethod.class);
+                return new ParametersProviderFactory() {
+                    @Override
+                    protected ParametersProvider<? extends Annotation> checkedNewInstance(Class<?> testClass, FrameworkMethod frameworkMethod)
+                            throws IllegalAccessException, InvocationTargetException, InstantiationException {
+                        checkNotNull(testClass, "testClass must not be null");
+                        checkNotNull(frameworkMethod, "frameworkMethod must not be null");
+                        return cons.newInstance(frameworkMethod);
+                    }
+                };
+            } catch (NoSuchMethodException ignored) {
+            }
+
+            try {
+                final Constructor<T> cons = providerClass.getConstructor(Class.class);
+                return new ParametersProviderFactory() {
+                    @Override
+                    protected ParametersProvider<? extends Annotation> checkedNewInstance(Class<?> testClass, FrameworkMethod frameworkMethod)
+                            throws IllegalAccessException, InvocationTargetException, InstantiationException {
+                        checkNotNull(testClass, "testClass must not be null");
+                        checkNotNull(frameworkMethod, "frameworkMethod must not be null");
+                        return cons.newInstance(testClass);
+                    }
+                };
+            } catch (NoSuchMethodException ignored) {
+            }
+
+            try {
+                final Constructor<T> cons = providerClass.getConstructor();
+                return new ParametersProviderFactory() {
+                    @Override
+                    protected ParametersProvider<? extends Annotation> checkedNewInstance(Class<?> testClass, FrameworkMethod frameworkMethod)
+                            throws IllegalAccessException, InvocationTargetException, InstantiationException {
+                        checkNotNull(testClass, "testClass must not be null");
+                        checkNotNull(frameworkMethod, "frameworkMethod must not be null");
+                        return cons.newInstance();
+                    }
+                };
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException("Your Provider class must have a public no-arg constructor!", e);
+            }
+        }
+
+        /**
+         * Creates a new instance of the {@link ParametersProvider}.
+         *
+         * @param testClass       the test class
+         * @param frameworkMethod the framework method
+         * @return the new {@link ParametersProvider} instance
+         * @throws IllegalAccessException    if the constructor is not accessible
+         * @throws InvocationTargetException if the constructor throws an exception
+         * @throws InstantiationException    if the class cannot be instantiated
+         */
+        protected abstract ParametersProvider<? extends Annotation> checkedNewInstance(Class<?> testClass, FrameworkMethod frameworkMethod)
+                throws IllegalAccessException, InvocationTargetException, InstantiationException;
+
+        /**
+         * Creates a new instance of the {@link ParametersProvider}.
+         *
+         * @param testClass       the test class
+         * @param frameworkMethod the framework method
+         * @return the new {@link ParametersProvider} instance
+         */
+        public ParametersProvider<? extends Annotation> newInstance(Class<?> testClass, FrameworkMethod frameworkMethod) {
+            try {
+                return checkedNewInstance(testClass, frameworkMethod);
+            } catch (InvocationTargetException e) {
+                if (e.getCause() != null) {
+                    throw Throwables.propagate(e.getCause());
+                }
+                throw Throwables.propagate(e);
+            } catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+        }
+    }
+
+    private final Class<?> testClass;
+    private final FrameworkMethod frameworkMethod;
     private final FrameworkMethodAnnotations frameworkMethodAnnotations;
 
-    ParametersFromCustomProvider(FrameworkMethod frameworkMethod) {
+    ParametersFromCustomProvider(Class<?> testClass, FrameworkMethod frameworkMethod) {
+        this.testClass = checkNotNull(testClass, "testClass must not be null");
+        this.frameworkMethod = checkNotNull(frameworkMethod, "frameworkMethod must not be null");
         frameworkMethodAnnotations = new FrameworkMethodAnnotations(frameworkMethod);
     }
 
@@ -22,17 +155,22 @@ class ParametersFromCustomProvider implements ParametrizationStrategy {
     @Override
     public Object[] getParameters() {
         CustomParametersDescriptor parameters = frameworkMethodAnnotations.getCustomParameters();
-        ParametersProvider provider = instantiate(parameters.provider());
+
+        // this cast is type-safe
+        @SuppressWarnings("unchecked") Class<? extends ParametersProvider<Annotation>> providerClass =
+                (Class<? extends ParametersProvider<Annotation>>) parameters.provider();
+
+        ParametersProvider<Annotation> provider = instantiate(providerClass);
         provider.initialize(parameters.annotation());
         return provider.getParameters();
     }
 
-    private ParametersProvider instantiate(Class<? extends ParametersProvider> providerClass) {
-        try {
-            return providerClass.newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException("Your Provider class must have a public no-arg constructor!", e);
-        }
-    }
+    @SuppressWarnings("unchecked")
+    private ParametersProvider<Annotation> instantiate(final Class<? extends ParametersProvider<?>> providerClass) {
+        checkNotNull(providerClass, "providerClass must not be null");
 
+        return (ParametersProvider<Annotation>) ParametersProviderFactory
+                .forType(providerClass)
+                .newInstance(testClass, frameworkMethod);
+    }
 }

--- a/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassMethod.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassMethod.java
@@ -1,23 +1,19 @@
 package junitparams.internal.parameters;
 
-import org.junit.runners.model.FrameworkMethod;
-
 import junitparams.NullType;
 import junitparams.Parameters;
+import org.junit.runners.model.FrameworkMethod;
 
-class ParametersFromExternalClassMethod implements ParametrizationStrategy {
-    private ParamsFromMethodCommon paramsFromMethodCommon;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class ParametersFromExternalClassMethod extends ParamsFromMethodCommon {
+
     private Parameters annotation;
 
-    ParametersFromExternalClassMethod(FrameworkMethod frameworkMethod) {
-        this.paramsFromMethodCommon = new ParamsFromMethodCommon(frameworkMethod);
-        annotation = frameworkMethod.getAnnotation(Parameters.class);
-    }
-
-    @Override
-    public Object[] getParameters() {
-        Class<?> sourceClass = annotation.source();
-        return paramsFromMethodCommon.paramsFromMethod(sourceClass);
+    ParametersFromExternalClassMethod(FrameworkMethod frameworkMethod, Parameters annotation,
+                                      ResultAdapter resultAdapter) {
+        super(frameworkMethod, annotation.source(), annotation, resultAdapter);
+        this.annotation = annotation;
     }
 
     @Override

--- a/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassProvideMethod.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassProvideMethod.java
@@ -13,13 +13,16 @@ import junitparams.NullType;
 import junitparams.Parameters;
 import junitparams.internal.parameters.toarray.ParamsToArrayConverter;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 class ParametersFromExternalClassProvideMethod implements ParametrizationStrategy {
+
     private final FrameworkMethod frameworkMethod;
     private final Parameters annotation;
 
-    ParametersFromExternalClassProvideMethod(FrameworkMethod frameworkMethod) {
-        this.frameworkMethod = frameworkMethod;
-        annotation = frameworkMethod.getAnnotation(Parameters.class);
+    ParametersFromExternalClassProvideMethod(FrameworkMethod frameworkMethod, Parameters annotation) {
+        this.frameworkMethod = checkNotNull(frameworkMethod, "frameworkMethod must not be null");
+        this.annotation = annotation;
     }
 
     @Override
@@ -82,7 +85,9 @@ class ParametersFromExternalClassProvideMethod implements ParametrizationStrateg
 
     private List<Object> getDataFromMethod(Method prividerMethod) throws IllegalAccessException, InvocationTargetException {
         Object result = prividerMethod.invoke(null);
-        Object[] resultsArray = new ParamsToArrayConverter(frameworkMethod).convert(result);
+        ImmutableParameterTypeSupplier parameterTypeSupplier =
+                ImmutableParameterTypeSupplier.of(frameworkMethod.getMethod().getParameterTypes());
+        Object[] resultsArray = new ParamsToArrayConverter(parameterTypeSupplier).convert(result);
         return Arrays.asList(resultsArray);
     }
 }

--- a/src/main/java/junitparams/internal/parameters/ParametersFromParametersAnnotation.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromParametersAnnotation.java
@@ -1,0 +1,112 @@
+package junitparams.internal.parameters;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import junitparams.Parameters;
+import org.junit.runners.model.FrameworkMethod;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+import static junitparams.internal.parameters.ParametersReader.ILLEGAL_STATE_EXCEPTION_MESSAGE;
+
+/**
+ * A {@link ParametrizationStrategy} for reading parameters given a {@link Parameters} annotation.
+ */
+public class ParametersFromParametersAnnotation implements ParametrizationStrategy {
+    private static final Predicate<ParametrizationStrategy> STRATEGY_IS_APPLICABLE =
+            new Predicate<ParametrizationStrategy>() {
+                @Override
+                public boolean apply(ParametrizationStrategy strategy) {
+                    return strategy.isApplicable();
+                }
+            };
+
+    private final ImmutableList<ParametrizationStrategy> strategies;
+    private final FrameworkMethod frameworkMethod;
+    private final Class<?> testClass;
+    private final Parameters annotation;
+
+    /**
+     * Read the array of parameters defined by the {@link Parameters} annotation in the current context.
+     *
+     * @param testClass       the context test class
+     * @param frameworkMethod th context test method
+     * @param annotation      the annotation to read
+     * @return the array of parameters
+     * @throws IllegalArgumentException if the {@link Parameters} annotation is invalid
+     */
+    public static Object[] parametersFor(Class<?> testClass, FrameworkMethod frameworkMethod, Parameters annotation, ResultAdapter resultAdapter) {
+        return ParametersFromParametersAnnotation.create(testClass, frameworkMethod, annotation, resultAdapter).getParameters();
+    }
+
+    /**
+     * Create a reader of {@link Parameters} annotation values.
+     *
+     * @param testClass       the context test class
+     * @param frameworkMethod th context test method
+     * @param annotation      the annotation to read
+     * @return the array of parameters
+     * @throws IllegalArgumentException if the {@link Parameters} annotation is invalid
+     */
+    static ParametersFromParametersAnnotation create(
+            Class<?> testClass, final FrameworkMethod frameworkMethod, Parameters annotation) {
+        return create(testClass, frameworkMethod, annotation, ResultAdapters.adaptParametersFor(frameworkMethod));
+    }
+
+    /**
+     * Create a reader of {@link Parameters} annotation values.
+     *
+     * @param testClass       the context test class
+     * @param frameworkMethod th context test method
+     * @param annotation      the annotation to read
+     * @param resultAdapter   the result adapter
+     * @return the array of parameters
+     * @throws IllegalArgumentException if the {@link Parameters} annotation is invalid
+     */
+    private static ParametersFromParametersAnnotation create(
+            Class<?> testClass, FrameworkMethod frameworkMethod, Parameters annotation, ResultAdapter resultAdapter) {
+        return new ParametersFromParametersAnnotation(testClass, frameworkMethod, annotation, resultAdapter);
+    }
+
+    private ParametersFromParametersAnnotation(Class<?> testClass, FrameworkMethod frameworkMethod, Parameters annotation,
+                                               ResultAdapter resultAdapter) {
+        this.testClass = checkNotNull(testClass, "testClass must not be null");
+        this.frameworkMethod = checkNotNull(frameworkMethod, "frameworkMethod must not be null");
+        this.annotation = checkNotNull(annotation, "annotation must not be null");
+
+        this.strategies = ImmutableList.of(
+                new ParametersFromValue(annotation),
+                new ParametersFromExternalClassProvideMethod(frameworkMethod, annotation),
+                new ParametersFromExternalClassMethod(frameworkMethod, annotation, resultAdapter),
+                new ParametersFromTestClassMethod(testClass, frameworkMethod, annotation, resultAdapter)
+        );
+    }
+
+    @Override
+    public Object[] getParameters() {
+        ImmutableList<ParametrizationStrategy> matchingStrategies = FluentIterable.from(strategies)
+                .filter(STRATEGY_IS_APPLICABLE)
+                .toList();
+        if (matchingStrategies.size() == 1) {
+            return Iterables.getOnlyElement(matchingStrategies).getParameters();
+        }
+        throw new IllegalStateException(format(ILLEGAL_STATE_EXCEPTION_MESSAGE, frameworkMethod.getName()));
+    }
+
+    @Override
+    public boolean isApplicable() {
+        return Iterables.any(strategies, STRATEGY_IS_APPLICABLE);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(ParametersFromParametersAnnotation.class)
+                .add("testClass", testClass)
+                .add("frameworkMethod", frameworkMethod)
+                .add("annotation", annotation)
+                .toString();
+    }
+}

--- a/src/main/java/junitparams/internal/parameters/ParametersFromTestClassMethod.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromTestClassMethod.java
@@ -6,26 +6,36 @@ import org.junit.runners.model.FrameworkMethod;
 import junitparams.NullType;
 import junitparams.Parameters;
 
-class ParametersFromTestClassMethod implements ParametrizationStrategy {
-    private final ParamsFromMethodCommon paramsFromMethodCommon;
+class ParametersFromTestClassMethod extends ParamsFromMethodCommon {
+
     private final Class<?> testClass;
     private final Parameters annotation;
 
-    ParametersFromTestClassMethod(FrameworkMethod frameworkMethod, Class<?> testClass) {
+    ParametersFromTestClassMethod(Class<?> testClass, FrameworkMethod frameworkMethod, Parameters annotation,
+                                  ResultAdapter resultAdapter) {
+        super(frameworkMethod, testClass, annotation, resultAdapter);
         this.testClass = testClass;
-        paramsFromMethodCommon = new ParamsFromMethodCommon(frameworkMethod);
-        annotation = frameworkMethod.getAnnotation(Parameters.class);
-    }
-
-    @Override
-    public Object[] getParameters() {
-        return paramsFromMethodCommon.paramsFromMethod(testClass);
+        this.annotation = annotation;
     }
 
     @Override
     public boolean isApplicable() {
         return annotation != null
-               && annotation.source().isAssignableFrom(NullType.class)
-               && (!annotation.method().isEmpty() || paramsFromMethodCommon.containsDefaultParametersProvidingMethod(testClass));
+                && annotation.source().isAssignableFrom(NullType.class)
+                && (!annotation.method().isEmpty() || canUseDefaultProvidingMethod());
+    }
+
+    /**
+     * Determine if can use a default providing method based on the test method name.
+     * <p>
+     * Note that this should only match when no arguments are given, i.e. {@code @Parameters}.
+     * <p>
+     * It does not make sense for this to match when explicit parameter values are provided so we do not match when
+     * the value array is not empty for example {@code @Parameters({"a", "b"}).
+     *
+     * @return true if it is possible to use the default providing method
+     */
+    private boolean canUseDefaultProvidingMethod() {
+        return annotation.value().length == 0 && containsDefaultParametersProvidingMethod(testClass);
     }
 }

--- a/src/main/java/junitparams/internal/parameters/ParametersFromValue.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromValue.java
@@ -8,7 +8,11 @@ class ParametersFromValue implements ParametrizationStrategy {
     private final Parameters parametersAnnotation;
 
     ParametersFromValue(FrameworkMethod frameworkMethod) {
-        parametersAnnotation = frameworkMethod.getAnnotation(Parameters.class);
+        this(frameworkMethod.getAnnotation(Parameters.class));
+    }
+
+    ParametersFromValue(Parameters annotation) {
+        parametersAnnotation = annotation;
     }
 
     @Override

--- a/src/main/java/junitparams/internal/parameters/ParametrizationStrategy.java
+++ b/src/main/java/junitparams/internal/parameters/ParametrizationStrategy.java
@@ -1,6 +1,6 @@
 package junitparams.internal.parameters;
 
-interface ParametrizationStrategy {
+public interface ParametrizationStrategy {
     Object[] getParameters();
     boolean isApplicable();
 }

--- a/src/main/java/junitparams/internal/parameters/ParametrizationStrategyFactory.java
+++ b/src/main/java/junitparams/internal/parameters/ParametrizationStrategyFactory.java
@@ -1,0 +1,19 @@
+package junitparams.internal.parameters;
+
+import org.junit.runners.model.FrameworkMethod;
+
+import java.util.List;
+
+/**
+ * A supplier of {@link ParametrizationStrategy} instances.
+ */
+public interface ParametrizationStrategyFactory {
+    /**
+     * Creates a set of parameterization strategies.
+     *
+     * @param testClass       the context test class
+     * @param frameworkMethod the context framework method
+     * @return the list of strategies
+     */
+    List<ParametrizationStrategy> createStrategies(Class<?> testClass, FrameworkMethod frameworkMethod);
+}

--- a/src/main/java/junitparams/internal/parameters/ResultAdapter.java
+++ b/src/main/java/junitparams/internal/parameters/ResultAdapter.java
@@ -1,0 +1,14 @@
+package junitparams.internal.parameters;
+
+/**
+ * Adapts a result to an array of members.
+ */
+public interface ResultAdapter {
+    /**
+     * Adapt a result object to an array of members.
+     *
+     * @param result the result object
+     * @return the array of members
+     */
+    Object[] adapt(Object result);
+}

--- a/src/main/java/junitparams/internal/parameters/ResultAdapters.java
+++ b/src/main/java/junitparams/internal/parameters/ResultAdapters.java
@@ -1,0 +1,38 @@
+package junitparams.internal.parameters;
+
+import junitparams.internal.parameters.toarray.ParamsToArrayConverter;
+import org.junit.runners.model.FrameworkMethod;
+
+/**
+ * A static utility class pertaining to {@link ResultAdapter} implementations.
+ */
+@SuppressWarnings("WeakerAccess")
+public class ResultAdapters {
+    /**
+     * A result adapter for producing parameters for a {@link FrameworkMethod}.
+     *
+     * @param frameworkMethod the framework method
+     * @return the result adapter
+     */
+    public static ResultAdapter adaptParametersFor(FrameworkMethod frameworkMethod) {
+        return new ParamsToArrayResultAdapter(frameworkMethod);
+    }
+
+    private static class ParamsToArrayResultAdapter implements ResultAdapter {
+        private final FrameworkMethod frameworkMethod;
+
+        private ParamsToArrayResultAdapter(FrameworkMethod frameworkMethod) {
+            this.frameworkMethod = frameworkMethod;
+        }
+
+        @Override
+        public Object[] adapt(Object result) {
+            return new ParamsToArrayConverter(
+                    ImmutableParameterTypeSupplier.copyFrom(frameworkMethod)
+            ).convert(result);
+        }
+    }
+
+    private ResultAdapters() {
+    }
+}

--- a/src/main/java/junitparams/internal/parameters/toarray/ObjectArrayResultToArray.java
+++ b/src/main/java/junitparams/internal/parameters/toarray/ObjectArrayResultToArray.java
@@ -1,14 +1,16 @@
 package junitparams.internal.parameters.toarray;
 
-import org.junit.runners.model.FrameworkMethod;
+import junitparams.internal.parameters.ParameterTypeSupplier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 class ObjectArrayResultToArray implements ResultToArray {
     private Object result;
-    private FrameworkMethod frameworkMethod;
+    private ParameterTypeSupplier parameterTypeSupplier;
 
-    ObjectArrayResultToArray(Object result, FrameworkMethod frameworkMethod) {
-        this.result = result;
-        this.frameworkMethod = frameworkMethod;
+    ObjectArrayResultToArray(Object result, ParameterTypeSupplier parameterTypeSupplier) {
+        this.result = checkNotNull(result, "result must not be null");
+        this.parameterTypeSupplier = checkNotNull(parameterTypeSupplier, "parameterTypeSupplier must not be null");
     }
 
     @Override
@@ -22,7 +24,7 @@ class ObjectArrayResultToArray implements ResultToArray {
     }
 
     private Object[] encapsulateParamsIntoArrayIfSingleParamsetPassed(Object[] params) {
-        if (frameworkMethod.getMethod().getParameterTypes().length != params.length) {
+        if (parameterTypeSupplier.getParameterTypes().size() != params.length) {
             return params;
         }
 

--- a/src/main/java/junitparams/internal/parameters/toarray/ParamsToArrayConverter.java
+++ b/src/main/java/junitparams/internal/parameters/toarray/ParamsToArrayConverter.java
@@ -1,22 +1,26 @@
 package junitparams.internal.parameters.toarray;
 
-import org.junit.runners.model.FrameworkMethod;
+import com.google.common.collect.Iterables;
+import junitparams.internal.parameters.ParameterTypeSupplier;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class ParamsToArrayConverter {
-    private FrameworkMethod frameworkMethod;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-    public ParamsToArrayConverter(FrameworkMethod frameworkMethod) {
-        this.frameworkMethod = frameworkMethod;
+public class ParamsToArrayConverter {
+    private ParameterTypeSupplier parameterTypeSupplier;
+
+    public ParamsToArrayConverter(ParameterTypeSupplier parameterTypeSupplier) {
+        this.parameterTypeSupplier = checkNotNull(parameterTypeSupplier, "parameterTypeSupplier must not be null");
     }
 
     public Object[] convert(Object result) {
         // handle single iterable parameter result case where result is
         // assignable to the test method parameter
-        if (frameworkMethod.getMethod().getParameterTypes().length == 1) {
-            Class<?> type = frameworkMethod.getMethod().getParameterTypes()[0];
+        List<Class<?>> parameterTypes = parameterTypeSupplier.getParameterTypes();
+        if (parameterTypes.size() == 1) {
+            Class<?> type = Iterables.getOnlyElement(parameterTypes);
             if (type.isAssignableFrom(result.getClass())) {
                 SimpleIterableResultToArray converter = new SimpleIterableResultToArray(result);
                 if (converter.isApplicable()) {
@@ -26,7 +30,7 @@ public class ParamsToArrayConverter {
         }
 
         List<? extends ResultToArray> converters = Arrays.asList(
-                new ObjectArrayResultToArray(result, frameworkMethod),
+                new ObjectArrayResultToArray(result, parameterTypeSupplier),
                 new IterableResultToArray(result),
                 new IteratorResultToArray(result)
         );

--- a/src/test/java/junitparams/custom/combined/CartesianParametersProviderTest.java
+++ b/src/test/java/junitparams/custom/combined/CartesianParametersProviderTest.java
@@ -1,0 +1,133 @@
+package junitparams.custom.combined;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class CartesianParametersProviderTest {
+
+    private static Verifier verifier = new Verifier();
+
+    private Iterable<String> suppliesForCalledWithCartesianProduct() {
+        return Arrays.asList("1", "2");
+    }
+
+    private Iterable<String> parametersForCalledWithCartesianProductAndTestMethod() {
+        return Arrays.asList("1", "2");
+    }
+
+    private static class AnotherParameterSource {
+        private Iterable<String> suppliesForCalledWithCartesianProduct() {
+            return Arrays.asList("1", "2");
+        }
+    }
+
+    @Test
+    @CartesianParameters({
+        @Parameters({"a", "b"}),
+        @Parameters({"1", "2"})
+    })
+    public void calledWithCartesianProduct(String character, String number) {
+        verifier.called(character, number);
+    }
+
+    @Test
+    @CartesianParameters({
+            @Parameters({"a", "b"}),
+            @Parameters(method = "suppliesForCalledWithCartesianProduct")
+    })
+    public void calledWithCartesianProductAndMethod(String character, String number) {
+        verifier.called(character, number);
+    }
+
+    @Test
+    @CartesianParameters({
+            @Parameters({"a", "b"}),
+            @Parameters(source = AnotherParameterSource.class, method = "suppliesForCalledWithCartesianProduct")
+    })
+    public void calledWithCartesianProductAndExternalMethod(String character, String number) {
+        verifier.called(character, number);
+    }
+
+    @Test
+    @CartesianParameters({
+            @Parameters({"a", "b"}),
+            @Parameters
+    })
+    public void calledWithCartesianProductAndTestMethod(String character, String number) {
+        verifier.called(character, number);
+    }
+
+    @AfterClass
+    public static void verify() {
+        assertThat(verifier.getCalls()).containsOnly(
+                new Verifier.Call("a", "1"),
+                new Verifier.Call("b", "1"),
+                new Verifier.Call("a", "2"),
+                new Verifier.Call("b", "2")
+        );
+    }
+
+    private static class Verifier {
+
+        private List<Call> calls = new LinkedList<Call>();
+
+        void called(String firstParam, String anotherParam){
+            calls.add(new Call(firstParam, anotherParam));
+        }
+
+        List<Call> getCalls() {
+            return calls;
+        }
+
+        private static class Call {
+
+            private final String firstParam;
+            private final String anotherParam;
+
+            Call(String firstParam, String anotherParam) {
+                this.firstParam = firstParam;
+                this.anotherParam = anotherParam;
+            }
+
+            @Override
+            public String toString() {
+                return "Call{" +
+                        "'" + firstParam + '\'' +
+                        ",'" + anotherParam + '\'' +
+                        '}';
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                Call call = (Call) o;
+
+                return firstParam.equals(call.firstParam) && anotherParam.equals(call.anotherParam);
+
+            }
+
+            @Override
+            public int hashCode() {
+                int result = firstParam.hashCode();
+                result = 31 * result + anotherParam.hashCode();
+                return result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add improved cartesian parameter handling allowing the form

```java
@CartesianParameters({
    @Parameters(method="a"),
    @Parameters(source=X.class),
    @Parameters(source=Y.class, method="b"),
    @Parameters({"c", "d"})
})
@Test
public void method(...) {}
```

for a simpler means of transitioning from non-cartesian to cartesian permutation form