### PR TITLE
Feature/named annotation

### DIFF
--- a/src/main/java/junitparams/Named.java
+++ b/src/main/java/junitparams/Named.java
@@ -5,8 +5,6 @@ import java.lang.annotation.RetentionPolicy;
 
 /**
  * An annotation for test parameter providers.
- *
- * @author Toby Terhoeven (toby@terhoeven.co.uk)
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Named {

--- a/src/main/java/junitparams/Named.java
+++ b/src/main/java/junitparams/Named.java
@@ -1,0 +1,26 @@
+package junitparams;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * An annotation for test parameter providers.
+ *
+ * @author Toby Terhoeven (toby@terhoeven.co.uk)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Named {
+	/**
+	 * Name of the set of parameters provided by a method.
+	 * <p>
+	 * On a test case, use the @see Parameters annotation with the
+	 * option "named" to link to use the corresponding parameters.
+	 * <p>
+	 * Example: <code>@Named("exemplaryPeople")</code>
+	 * <p>
+	 * Corresponding test case annotation example:
+	 * <p>
+	 * <code>@Parameters(named = "exemplaryPeople")</code>
+	 */
+	String value() default "";
+}

--- a/src/main/java/junitparams/Parameters.java
+++ b/src/main/java/junitparams/Parameters.java
@@ -39,10 +39,22 @@ public @interface Parameters {
      * don't need additional classes and the test code may be a bit cleaner. The
      * format of the data returned by the method is the same as for the source
      * annotation class.
-     * Example: <code>@Parameters(method = "examplaryPeople")</code>
+     * Example: <code>@Parameters(method = "exemplaryPeople")</code>
      * <p>
      * You can use multiple methods to provide parameters - use comma to do it:
      * Example: <code>@Parameters(method = "womenParams, menParams")</code>
      */
     String method() default "";
+
+    /**
+     * Parameter values returned by a named method within the test class, with
+     * @see Named annotation. This way you don't need additional classes and
+     * the test code may be a bit cleaner. The format of the data returned
+     * by the method is the same as for the source annotation class.
+     * Example: <code>@Parameters(named = "exemplaryPeople")</code>
+     * <p>
+     * You can use multiple methods to provide parameters - use comma to do it:
+     * Example: <code>@Parameters(named = "womenParams, menParams")</code>
+     */
+    String named() default "";
 }

--- a/src/main/java/junitparams/Parameters.java
+++ b/src/main/java/junitparams/Parameters.java
@@ -53,7 +53,7 @@ public @interface Parameters {
      * by the method is the same as for the source annotation class.
      * Example: <code>@Parameters(named = "exemplaryPeople")</code>
      * <p>
-     * You can use multiple methods to provide parameters - use comma to do it:
+     * You can use multiple named methods to provide parameters - use comma to do it:
      * Example: <code>@Parameters(named = "womenParams, menParams")</code>
      */
     String named() default "";

--- a/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassMethod.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassMethod.java
@@ -17,13 +17,15 @@ class ParametersFromExternalClassMethod implements ParametrizationStrategy {
     @Override
     public Object[] getParameters() {
         Class<?> sourceClass = annotation.source();
-        return paramsFromMethodCommon.paramsFromMethod(sourceClass);
+        return !annotation.method().isEmpty()
+            ? paramsFromMethodCommon.paramsFromMethod(sourceClass)
+            : paramsFromMethodCommon.paramsFromNamedMethod(sourceClass);
     }
 
     @Override
     public boolean isApplicable() {
         return annotation != null
                 && !annotation.source().isAssignableFrom(NullType.class)
-                && !annotation.method().isEmpty();
+                && (!annotation.method().isEmpty() || ! annotation.named().isEmpty());
     }
 }

--- a/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassProvideMethod.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromExternalClassProvideMethod.java
@@ -32,7 +32,8 @@ class ParametersFromExternalClassProvideMethod implements ParametrizationStrateg
     public boolean isApplicable() {
         return annotation != null
                 && !annotation.source().isAssignableFrom(NullType.class)
-                && annotation.method().isEmpty();
+                && annotation.method().isEmpty()
+                && annotation.named().isEmpty();
     }
 
     private Object[] fillResultWithAllParamProviderMethods(Class<?> sourceClass) {

--- a/src/main/java/junitparams/internal/parameters/ParametersFromNamedTestClassMethod.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersFromNamedTestClassMethod.java
@@ -1,17 +1,15 @@
 package junitparams.internal.parameters;
 
-
-import org.junit.runners.model.FrameworkMethod;
-
 import junitparams.NullType;
 import junitparams.Parameters;
+import org.junit.runners.model.FrameworkMethod;
 
-class ParametersFromTestClassMethod implements ParametrizationStrategy {
+class ParametersFromNamedTestClassMethod implements ParametrizationStrategy {
     private final ParamsFromMethodCommon paramsFromMethodCommon;
     private final Class<?> testClass;
     private final Parameters annotation;
 
-    ParametersFromTestClassMethod(FrameworkMethod frameworkMethod, Class<?> testClass) {
+    ParametersFromNamedTestClassMethod(FrameworkMethod frameworkMethod, Class<?> testClass) {
         this.testClass = testClass;
         paramsFromMethodCommon = new ParamsFromMethodCommon(frameworkMethod);
         annotation = frameworkMethod.getAnnotation(Parameters.class);
@@ -19,14 +17,14 @@ class ParametersFromTestClassMethod implements ParametrizationStrategy {
 
     @Override
     public Object[] getParameters() {
-        return paramsFromMethodCommon.paramsFromMethod(testClass);
+        return paramsFromMethodCommon.paramsFromNamedMethod(testClass);
     }
 
     @Override
     public boolean isApplicable() {
         return annotation != null
                 && annotation.source().isAssignableFrom(NullType.class)
-                && (!annotation.method().isEmpty() || paramsFromMethodCommon.containsDefaultParametersProvidingMethod(testClass))
-                && annotation.named().isEmpty();
+                && annotation.method().isEmpty()
+                && !annotation.named().isEmpty();
     }
 }

--- a/src/main/java/junitparams/internal/parameters/ParametersReader.java
+++ b/src/main/java/junitparams/internal/parameters/ParametersReader.java
@@ -30,7 +30,8 @@ public class ParametersReader {
                 new ParametersFromValue(frameworkMethod),
                 new ParametersFromExternalClassProvideMethod(frameworkMethod),
                 new ParametersFromExternalClassMethod(frameworkMethod),
-                new ParametersFromTestClassMethod(frameworkMethod, testClass)
+                new ParametersFromTestClassMethod(frameworkMethod, testClass),
+                new ParametersFromNamedTestClassMethod(frameworkMethod, testClass)
         );
     }
 

--- a/src/main/java/junitparams/internal/parameters/ParamsFromMethodCommon.java
+++ b/src/main/java/junitparams/internal/parameters/ParamsFromMethodCommon.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import junitparams.Named;
 import org.junit.runners.model.FrameworkMethod;
 
 import junitparams.Parameters;
@@ -32,6 +33,22 @@ class ParamsFromMethodCommon {
         return result.toArray();
     }
 
+    Object[] paramsFromNamedMethod(Class<?> sourceClass) {
+        String namedMethodAnnotation = frameworkMethod.getAnnotation(Parameters.class).named();
+
+        if (namedMethodAnnotation.isEmpty()) {
+            return invokeMethodWithParams(defaultMethodName(), sourceClass);
+        }
+
+        List<Object> result = new ArrayList<Object>();
+        for (String name : namedMethodAnnotation.split(",")) {
+            for (Object param : invokeNamedMethodWithParams(name.trim(), sourceClass))
+                result.add(param);
+        }
+
+        return result.toArray();
+    }
+
     boolean containsDefaultParametersProvidingMethod(Class<?> sourceClass) {
         return findMethodInTestClassHierarchy(defaultMethodName(), sourceClass) != null;
     }
@@ -45,6 +62,15 @@ class ParamsFromMethodCommon {
         Method providerMethod = findMethodInTestClassHierarchy(methodName, sourceClass);
         if (providerMethod == null) {
             throw new RuntimeException("Could not find method: " + methodName + " so no params were used.");
+        }
+
+        return invokeParamsProvidingMethod(providerMethod, sourceClass);
+    }
+
+    private Object[] invokeNamedMethodWithParams(String name, Class<?> sourceClass) {
+        Method providerMethod = findNamedMethodInTestClassHierarchy(name, sourceClass);
+        if (providerMethod == null) {
+            throw new RuntimeException("Could not find method with Named annotation: " + name + " so no params were used.");
         }
 
         return invokeParamsProvidingMethod(providerMethod, sourceClass);
@@ -82,5 +108,20 @@ class ParamsFromMethodCommon {
         return null;
     }
 
-
+    private Method findNamedMethodInTestClassHierarchy(String name, Class<?> sourceClass) {
+        Class<?> declaringClass = sourceClass;
+        while (declaringClass.getSuperclass() != null) {
+            try {
+                Method[] methods = declaringClass.getDeclaredMethods();
+                for (Method method : methods) {
+                    if (method.isAnnotationPresent(Named.class) && name.equals(method.getAnnotation(Named.class).value())) {
+                        return method;
+                    }
+                }
+            } catch (Exception ignore) {
+            }
+            declaringClass = declaringClass.getSuperclass();
+        }
+        return null;
+    }
 }

--- a/src/test/java/junitparams/NamedAnnotationArgumentTest.java
+++ b/src/test/java/junitparams/NamedAnnotationArgumentTest.java
@@ -1,0 +1,84 @@
+package junitparams;
+
+import junitparams.usage.person_example.PersonTest;
+import junitparams.usage.person_example.PersonTest.Person;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("unused")
+@RunWith(JUnitParamsRunner.class)
+public class NamedAnnotationArgumentTest {
+
+    @Test
+    @Parameters(named = "return1")
+    public void testSingleNamedMethods(int number) {
+        assertThat(number).isEqualTo(1);
+    }
+
+    @Named("return1")
+    private Integer[] returnNumberOne() {
+        return new Integer[] { 1 };
+    }
+
+    @Test
+    @Parameters(named = "return1,return2")
+    public void testMultipleNamedMethods(int number) {
+        assertThat(number)
+                .isLessThanOrEqualTo(2)
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    @Parameters(named = "return1, return2")
+    public void testMultipleNamedMethodsWithWhitespaces(int number) {
+        assertThat(number)
+                .isLessThanOrEqualTo(2)
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    @Named("return2")
+    private Integer[] returnNumberTwo() {
+        return new Integer[] { 2 };
+    }
+
+    @Test
+    @Parameters(source = PersonTest.class, named = "grownups")
+    public void testSingleMethodFromDifferentClass(int age, boolean valid) {
+        assertThat(new Person(age).isAdult()).isEqualTo(valid);
+    }
+
+    @Test
+    @Parameters(named = "stringParamsWithNull")
+    public void shouldPassStringParamsWithNullFromMethod(String parameter) {
+        List<String> acceptedParams = Arrays.asList("1", "2", "3", null);
+
+        assertThat(acceptedParams).contains(parameter);
+    }
+
+    @Named("stringParamsWithNull")
+    Object[] stringWithNullParameters() {
+        return genericArray("1", "2", "3", null);
+    }
+
+    @Test
+    @Parameters(named = "multiStringParams")
+    public void shouldPassMultiStringParams(String first, String second) {
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Named("multiStringParams")
+    Object[] multiStringParameters() {
+        return genericArray(
+                genericArray("test", "test"),
+                genericArray("ble", "ble"));
+    }
+
+    private static <T> T[] genericArray(T... elements) {
+        return elements;
+    }
+}

--- a/src/test/java/junitparams/NamedAnnotationArgumentTest.java
+++ b/src/test/java/junitparams/NamedAnnotationArgumentTest.java
@@ -16,7 +16,7 @@ public class NamedAnnotationArgumentTest {
 
     @Test
     @Parameters(named = "return1")
-    public void testSingleNamedMethods(int number) {
+    public void testSingleNamedMethod(int number) {
         assertThat(number).isEqualTo(1);
     }
 

--- a/src/test/java/junitparams/usage/person_example/PersonTest.java
+++ b/src/test/java/junitparams/usage/person_example/PersonTest.java
@@ -25,6 +25,7 @@ public class PersonTest {
         assertThat(new Person(age).isAdult()).isEqualTo(valid);
     }
 
+    @Named("grownups")
     private Object[] adultValues() {
         return new Object[]{new Object[]{17, false}, new Object[]{22, true}};
     }


### PR DESCRIPTION
Great project, thank you! We're using JUnitParams on a project and it's working really well, but we were missing a more standardised way to link parameters to test cases, without using the method names or putting everything into the test case annotation.

This pull request contains a new annotation for parameters, so this could be used as such:

    @Test
    @Parameters(named = "return1")
    public void testSingleNamedMethod(int number) {
        assertThat(number).isEqualTo(1);
    }

    @Named("return1")
    private Integer[] returnNumberOne() {
        return new Integer[] { 1 };
    }