### PR TITLE
throw IllegalStateException if methodInvoker is Fail

### DIFF
--- a/src/main/java/junitparams/internal/ParameterisedTestMethodRunner.java
+++ b/src/main/java/junitparams/internal/ParameterisedTestMethodRunner.java
@@ -1,12 +1,13 @@
 package junitparams.internal;
 
-import java.lang.reflect.Field;
-
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.internal.runners.statements.Fail;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.Statement;
+
+import java.lang.reflect.Field;
 
 /**
  * Testmethod-level functionalities for parameterised tests
@@ -68,6 +69,14 @@ public class ParameterisedTestMethodRunner {
     }
 
     private InvokeParameterisedMethod findParameterisedMethodInvokerInChain(Statement methodInvoker) {
+        if (methodInvoker != null && methodInvoker instanceof Fail) {
+            try {
+                methodInvoker.evaluate();
+            } catch (Throwable throwable) {
+                throw new IllegalStateException("Instantiation failed", throwable);
+            }
+        }
+
         while (methodInvoker != null && !(methodInvoker instanceof InvokeParameterisedMethod))
             methodInvoker = nextChainedInvoker(methodInvoker);
 


### PR DESCRIPTION
Added throwing illegalStateException as if it is not added then this error is masked by RuntimeException with message "Cannot find invoker for the parameterised method. Using wrong JUnit version?" which might not be the case for test methods in which there are some instantiation problem.

As a client of this I was forced to debug library to see what happens. So here is PR.