### PR TITLE
Fixes #44: Show original exception thrown from test class constructor

### DIFF
--- a/src/test/java/junitparams/internal/JUnitParamsRunnerTest.java
+++ b/src/test/java/junitparams/internal/JUnitParamsRunnerTest.java
@@ -1,0 +1,47 @@
+package junitparams.internal;
+
+import junitparams.JUnitParamsRunner;
+import org.assertj.core.api.iterable.Extractor;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class JUnitParamsRunnerTest {
+
+    private static final RuntimeException TEST_EXCEPTION = new RuntimeException("Test Exception");
+
+    @Test
+    public void shouldGetOriginalExceptionThrownBySampleTestConstructor() {
+        final Result testResult = JUnitCore.runClasses(ExceptionInSampleTestConstructorTest.class);
+        final Extractor<Failure, Throwable> throwableProperty = new Extractor<Failure, Throwable>() {
+            @Override
+            public Throwable extract(Failure failure) {
+                return failure.getException();
+            }
+        };
+        assertThat(testResult.getFailures())
+                .extracting(throwableProperty)
+                .contains(TEST_EXCEPTION);
+    }
+
+    @RunWith(JUnitParamsRunner.class)
+    public static class ExceptionInSampleTestConstructorTest {
+
+        @SuppressWarnings("WeakerAccess")
+        public ExceptionInSampleTestConstructorTest() {
+            throw TEST_EXCEPTION;
+        }
+
+        @Test
+        @SuppressWarnings({"unused", "WeakerAccess"})
+        public void testCase() {
+            fail("Should not be invoked");
+        }
+
+    }
+}


### PR DESCRIPTION
Fix for #44. The PR addresses the issue described in [the comment](https://github.com/Pragmatists/JUnitParams/issues/44#issuecomment-102470585). The issue was closed already. However, the bug still exists. I spent almost an hour figuring out what's wrong. The problem was that when the test class constructor throws an exception: 
```java
@RunWith(JUnitParamsRunner.class)
public class FailingTest {

    public FailingTest() {
        throw new RuntimeException();
    }

    @Test
    public void aTest() {}

}
```
then the error message provided by the `JUnitParamsRunner` is not accurate, and the actual exception is swallowed (no stack trace available):
```
java.lang.RuntimeException: Cannot find invoker for the parameterised method. Using wrong JUnit version?

	at junitparams.internal.ParameterisedTestMethodRunner.findParameterisedMethodInvokerInChain(ParameterisedTestMethodRunner.java:75)
	at junitparams.internal.ParameterisedTestMethodRunner.findChildForParams(ParameterisedTestMethodRunner.java:61)
	at junitparams.internal.ParameterisedTestMethodRunner.runTestMethod(ParameterisedTestMethodRunner.java:38)
	at junitparams.internal.ParameterisedTestClassRunner.runParameterisedTest(ParameterisedTestClassRunner.java:146)
	at junitparams.JUnitParamsRunner.runChild(JUnitParamsRunner.java:446)
	at junitparams.JUnitParamsRunner.runChild(JUnitParamsRunner.java:393)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```
The issue is especially annoying when you have only parametrized test case(s) in your test class. Then you will see no exception thrown from a constructor unless you have at least one regular (parametless) test case (in that case the exception can be seen in test case initialization).
  
  