### PR TITLE
Fix ci build due to discontinued support for TLSv1.1 and below

### DIFF
--- a/.travis.maven.settings.xml
+++ b/.travis.maven.settings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+        <profile>
+            <id>jdk-1.6</id>
+
+            <activation>
+                <jdk>1.6</jdk>
+            </activation>
+
+            <repositories>
+                <repository>
+                    <id>jdk16</id>
+                    <name>Repository for JDK 1.6 builds</name>
+                    <url>http://repo1.maven.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>jdk16</id>
+                    <name>Plugin repository for JDK 1.6 builds</name>
+                    <url>http://repo1.maven.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 dist: precise
 before_install:
   - cp .travis.maven.settings.xml $HOME/.m2/settings.xml
+  - echo "MAVEN_OPTS=-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2" > ~/.mavenrc
 install: mvn install -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 dist: precise
+before_install:
+  - cp .travis.maven.settings.xml $HOME/.m2/settings.xml
 install: mvn install -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Dear @michal-lipski 

Since TLSv1.1 and below are not supported any more by sonatype central servers I have provided a fix to make the build working again.

Here are the details about the discontinued support:
https://central.sonatype.org/articles/2018/May/04/discontinued-support-for-tlsv11-and-below/?__hstc=31049440.187dbfa47d81679cd6c7143b8ae12a45.1537306920752.1537311968129.1537469982357.3&__hssc=31049440.1.1537469982357&__hsfp=4156835369